### PR TITLE
Add SEED-ALS portal routing and navigation scaffolding

### DIFF
--- a/apps/stage/components/NavBar/NavBar.tsx
+++ b/apps/stage/components/NavBar/NavBar.tsx
@@ -5,18 +5,22 @@ import { createRef, ReactElement } from 'react';
 
 import { getConfig } from '../../global/config';
 import useAuthContext from '../../global/hooks/useAuthContext';
-import { ARRANGER_GQL, ELASTICVUE_DOCS, INTERNAL_PATHS, LOGIN_PATH, USER_PATH } from '../../global/utils/constants';
+import { INTERNAL_PATHS, LOGIN_PATH, USER_PATH } from '../../global/utils/constants';
 import { InternalLink, StyledLinkAsButton } from '../Link';
 import defaultTheme from '../theme';
 import UserDropdown from '../UserDropdown';
 
 import labIcon from '@/public/images/navbar-logo.png';
-import DataTablesDropdown from './DataTablesDropdown';
-import DocumentationDropdown from './DocumentationDropdown';
-import Dropdown from './Dropdown';
-import { StyledListLink } from './styles';
 
 export const navBarRef = createRef<HTMLDivElement>();
+
+const navItems = [
+	{ path: INTERNAL_PATHS.ALS_OVERVIEW, label: 'ALS Overview' },
+	{ path: INTERNAL_PATHS.EGA_EXPLORER, label: 'EGA Explorer' },
+	{ path: INTERNAL_PATHS.DISEASE_MODEL, label: 'Disease Model' },
+	{ path: INTERNAL_PATHS.DATA_SOURCES, label: 'Data Sources' },
+	{ path: INTERNAL_PATHS.ABOUT, label: 'About' },
+];
 
 const NavBar = (): ReactElement => {
 	const router = useRouter();
@@ -69,7 +73,7 @@ const NavBar = (): ReactElement => {
 					>
 						<img
 							src={labIcon.src}
-							alt="Prelude Logo"
+							alt="SEED-ALS Logo"
 							css={css`
 								width: ${theme.dimensions.labIcon.width}px;
 								height: auto;
@@ -117,111 +121,43 @@ const NavBar = (): ReactElement => {
 						color: ${theme.colors.black};
 					`}
 				>
-					<div
-						css={(theme) => css`
-							display: flex;
-							align-items: center;
-							justify-content: center;
-							width: 144px;
-							background-color: ${theme.colors.white};
-							height: 100%;
-							&:hover {
-								background-color: ${theme.colors.grey_2};
-							}
-							border-right: 2px solid ${theme.colors.white};
-							margin: 0;
-						`}
-					>
-						<DataTablesDropdown />
-					</div>
-					{/* <div
-						css={(theme) => css`
-							display: flex;
-							align-items: center;
-							justify-content: center;
-							width: 144px;
-							background-color: ${theme.colors.white};
-							height: 100%;
-							&:hover {
-								background-color: ${theme.colors.grey_2};
-							}
-							border-right: 2px solid ${theme.colors.white};
-							margin: 0;
-							${router.pathname === INTERNAL_PATHS.DICTIONARY ? activeLinkStyle : ''}
-						`}
-					>
-						<InternalLink path={INTERNAL_PATHS.DICTIONARY}>
-							<a
-								css={css`
-									width: 100%;
-									height: 100%;
-									display: flex;
-									align-items: center;
-									justify-content: center;
-									color: ${theme.colors.accent_dark};
-									font-size: 14px;
-									font-weight: bold;
-									text-decoration: none;
-								`}
-							>
-								Data Dictionary
-							</a>
-						</InternalLink>
-					</div> */}
-					<div
-						css={(theme) => css`
-							display: flex;
-							align-items: center;
-							justify-content: center;
-							width: 144px;
-							background-color: ${theme.colors.white};
-							height: 100%;
-							&:hover {
-								background-color: ${theme.colors.grey_2};
-							}
-							border-right: 2px solid ${theme.colors.white};
-							margin: 0;
-						`}
-					>
-						<DocumentationDropdown />
-					</div>
-					<div
-						css={(theme) => css`
-							display: flex;
-							align-items: center;
-							justify-content: center;
-							width: 144px;
-							background-color: ${theme.colors.white};
-							height: 100%;
-							&:hover {
-								background-color: ${theme.colors.grey_2};
-							}
-							border-right: 2px solid ${theme.colors.white};
-							margin: 0;
-						`}
-					>
-						<Dropdown
-							css={css`
-								width: 100%;
-								height: 100%;
+					{navItems.map(({ path, label }) => (
+						<div
+							key={path}
+							css={(theme) => css`
 								display: flex;
 								align-items: center;
 								justify-content: center;
-								color: ${theme.colors.accent_dark};
-								font-size: 14px;
-								font-weight: bold;
+								width: 144px;
+								background-color: ${theme.colors.white};
+								height: 100%;
+								&:hover {
+									background-color: ${theme.colors.grey_2};
+								}
+								border-right: 2px solid ${theme.colors.white};
+								margin: 0;
+								${router.pathname === path ? activeLinkStyle : ''}
 							`}
-							data={[
-								<a href={ARRANGER_GQL} target="_blank" rel="noopener noreferrer">
-									<StyledListLink>GraphQL API</StyledListLink>
-								</a>,
-								<a href={ELASTICVUE_DOCS} target="_blank" rel="noopener noreferrer">
-									<StyledListLink>ElasticVue</StyledListLink>
-								</a>,
-							]}
-							label="APIs"
-						/>
-					</div>
+						>
+							<InternalLink path={path}>
+								<a
+									css={css`
+										width: 100%;
+										height: 100%;
+										display: flex;
+										align-items: center;
+										justify-content: center;
+										color: ${theme.colors.accent_dark};
+										font-size: 14px;
+										font-weight: bold;
+										text-decoration: none;
+									`}
+								>
+									{label}
+								</a>
+							</InternalLink>
+						</div>
+					))}
 				</div>
 
 				{/* Auth Section */}

--- a/apps/stage/components/pages/about/index.tsx
+++ b/apps/stage/components/pages/about/index.tsx
@@ -1,0 +1,22 @@
+import { css } from '@emotion/react';
+import { ReactElement } from 'react';
+import PageLayout from '../../PageLayout';
+
+const About = (): ReactElement => (
+	<PageLayout subtitle="About">
+		<div
+			css={css`
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				padding: 60px 20px;
+			`}
+		>
+			<h1>About SEED-ALS</h1>
+			<p>Information about the SEED-ALS project, team, institutions, and acknowledgements.</p>
+		</div>
+	</PageLayout>
+);
+
+export default About;

--- a/apps/stage/components/pages/alsOverview/index.tsx
+++ b/apps/stage/components/pages/alsOverview/index.tsx
@@ -1,0 +1,22 @@
+import { css } from '@emotion/react';
+import { ReactElement } from 'react';
+import PageLayout from '../../PageLayout';
+
+const AlsOverview = (): ReactElement => (
+	<PageLayout subtitle="ALS Overview">
+		<div
+			css={css`
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				padding: 60px 20px;
+			`}
+		>
+			<h1>ALS Disease Overview</h1>
+			<p>This section will provide a comprehensive overview of Amyotrophic Lateral Sclerosis.</p>
+		</div>
+	</PageLayout>
+);
+
+export default AlsOverview;

--- a/apps/stage/components/pages/dataSources/index.tsx
+++ b/apps/stage/components/pages/dataSources/index.tsx
@@ -1,0 +1,22 @@
+import { css } from '@emotion/react';
+import { ReactElement } from 'react';
+import PageLayout from '../../PageLayout';
+
+const DataSources = (): ReactElement => (
+	<PageLayout subtitle="Data Sources">
+		<div
+			css={css`
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				padding: 60px 20px;
+			`}
+		>
+			<h1>Data Sources</h1>
+			<p>This section will explain the main data sources used in the portal: Monarch Initiative and EGA.</p>
+		</div>
+	</PageLayout>
+);
+
+export default DataSources;

--- a/apps/stage/components/pages/diseaseModel/index.tsx
+++ b/apps/stage/components/pages/diseaseModel/index.tsx
@@ -1,0 +1,22 @@
+import { css } from '@emotion/react';
+import { ReactElement } from 'react';
+import PageLayout from '../../PageLayout';
+
+const DiseaseModel = (): ReactElement => (
+	<PageLayout subtitle="Disease Model">
+		<div
+			css={css`
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				padding: 60px 20px;
+			`}
+		>
+			<h1>Disease Model</h1>
+			<p>This section will display machine learning analysis results and visualizations.</p>
+		</div>
+	</PageLayout>
+);
+
+export default DiseaseModel;

--- a/apps/stage/components/pages/egaExplorer/index.tsx
+++ b/apps/stage/components/pages/egaExplorer/index.tsx
@@ -1,0 +1,22 @@
+import { css } from '@emotion/react';
+import { ReactElement } from 'react';
+import PageLayout from '../../PageLayout';
+
+const EgaExplorer = (): ReactElement => (
+	<PageLayout subtitle="EGA Explorer">
+		<div
+			css={css`
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				padding: 60px 20px;
+			`}
+		>
+			<h1>EGA Metadata Explorer</h1>
+			<p>This section will allow exploring public metadata from ALS-related studies in the European Genome-phenome Archive.</p>
+		</div>
+	</PageLayout>
+);
+
+export default EgaExplorer;

--- a/apps/stage/global/utils/constants.ts
+++ b/apps/stage/global/utils/constants.ts
@@ -46,6 +46,11 @@ export enum INTERNAL_PATHS {
 	LECTERN = '/swaggerDocs/lectern',
 	SCORE = '/swaggerDocs/score',
 	DICTIONARY = '/dictionary',
+	ALS_OVERVIEW = '/als-overview',
+	EGA_EXPLORER = '/ega-explorer',
+	DISEASE_MODEL = '/disease-model',
+	DATA_SOURCES = '/data-sources',
+	ABOUT = '/about',
 }
 
 // external Swagger links

--- a/apps/stage/pages/about/index.tsx
+++ b/apps/stage/pages/about/index.tsx
@@ -1,0 +1,8 @@
+import About from '@/components/pages/about';
+import { createPage } from '../../global/utils/pages';
+
+const AboutPage = createPage({
+	isPublic: true,
+})(() => <About />);
+
+export default AboutPage;

--- a/apps/stage/pages/als-overview/index.tsx
+++ b/apps/stage/pages/als-overview/index.tsx
@@ -1,0 +1,8 @@
+import AlsOverview from '@/components/pages/alsOverview';
+import { createPage } from '../../global/utils/pages';
+
+const AlsOverviewPage = createPage({
+	isPublic: true,
+})(() => <AlsOverview />);
+
+export default AlsOverviewPage;

--- a/apps/stage/pages/data-sources/index.tsx
+++ b/apps/stage/pages/data-sources/index.tsx
@@ -1,0 +1,8 @@
+import DataSources from '@/components/pages/dataSources';
+import { createPage } from '../../global/utils/pages';
+
+const DataSourcesPage = createPage({
+	isPublic: true,
+})(() => <DataSources />);
+
+export default DataSourcesPage;

--- a/apps/stage/pages/disease-model/index.tsx
+++ b/apps/stage/pages/disease-model/index.tsx
@@ -1,0 +1,8 @@
+import DiseaseModel from '@/components/pages/diseaseModel';
+import { createPage } from '../../global/utils/pages';
+
+const DiseaseModelPage = createPage({
+	isPublic: true,
+})(() => <DiseaseModel />);
+
+export default DiseaseModelPage;

--- a/apps/stage/pages/ega-explorer/index.tsx
+++ b/apps/stage/pages/ega-explorer/index.tsx
@@ -1,0 +1,8 @@
+import EgaExplorer from '@/components/pages/egaExplorer';
+import { createPage } from '../../global/utils/pages';
+
+const EgaExplorerPage = createPage({
+	isPublic: true,
+})(() => <EgaExplorer />);
+
+export default EgaExplorerPage;


### PR DESCRIPTION
## Summary
Add new routes (als-overview, ega-explorer, disease-model, data-sources, about) with placeholder pages and updated NavBar replacing Overture template items.

## Changes

**New files (10):**
- `pages/`: `als-overview`, `ega-explorer`, `disease-model`, `data-sources`, `about`
- `components/pages/`: `alsOverview`, `egaExplorer`, `diseaseModel`, `dataSources`, `about`

**Modified files (3):**
- `global/utils/constants.ts` — new route entries in `INTERNAL_PATHS`
- `components/NavBar/NavBar.tsx` — replaced template dropdowns with SEED-ALS nav links
  
## Issues
Closes #1  