### PR TITLE
Integrate Monarch Initiative API for ALS disease data

### DIFF
--- a/apps/stage/global/hooks/useMonarchData.ts
+++ b/apps/stage/global/hooks/useMonarchData.ts
@@ -1,0 +1,75 @@
+// Hook for fetching Monarch Initiative data in React components
+// Usage: const { entity, loading, error, fetchAssociations } = useMonarchData('MONDO:0004976');
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { fetchDiseaseEntity, fetchDiseaseAssociations } from '../services/monarchApi';
+import { MonarchEntity, MonarchAssociationResponse } from '../types/monarch';
+
+interface UseMonarchDataResult {
+	entity: MonarchEntity | null;
+	loading: boolean;
+	error: string | null;
+	fetchAssociations: (
+		category: string,
+		limit?: number,
+		offset?: number,
+	) => Promise<MonarchAssociationResponse>;
+}
+
+/**
+ * Hook that fetches disease entity data on mount and provides
+ * a function to fetch associations on demand.
+ *
+ * - `entity` loads automatically when the component mounts
+ * - `fetchAssociations` is called manually when you need association data
+ *   (e.g. when a user clicks a tab or scrolls to a section)
+ */
+export function useMonarchData(mondoId: string): UseMonarchDataResult {
+	const [entity, setEntity] = useState<MonarchEntity | null>(null);
+	const [loading, setLoading] = useState<boolean>(true);
+	const [error, setError] = useState<string | null>(null);
+
+	// Fetch entity data on mount
+	useEffect(() => {
+		let cancelled = false;
+
+		async function loadEntity() {
+			setLoading(true);
+			setError(null);
+
+			try {
+				const data = await fetchDiseaseEntity(mondoId);
+				if (!cancelled) {
+					setEntity(data);
+				}
+			} catch (err) {
+				if (!cancelled) {
+					setError(err instanceof Error ? err.message : 'Failed to fetch disease data');
+				}
+			} finally {
+				if (!cancelled) {
+					setLoading(false);
+				}
+			}
+		}
+
+		loadEntity();
+
+		// Cleanup: if the component unmounts before the fetch finishes,
+		// we mark it as cancelled so we don't update state on an unmounted component
+		return () => {
+			cancelled = true;
+		};
+	}, [mondoId]);
+
+	// Fetch associations on demand — not automatic, called by the component when needed
+	const fetchAssociations = useCallback(
+		(category: string, limit?: number, offset?: number) => {
+			return fetchDiseaseAssociations(mondoId, category, limit, offset);
+		},
+		[mondoId],
+	);
+
+	return { entity, loading, error, fetchAssociations };
+}

--- a/apps/stage/global/services/monarchApi.ts
+++ b/apps/stage/global/services/monarchApi.ts
@@ -1,0 +1,63 @@
+// Service layer for Monarch Initiative API v3
+// Pure functions — no React dependencies
+
+import { MONARCH_API_BASE_URL } from '../utils/constants';
+import { MonarchEntity, MonarchAssociationResponse } from '../types/monarch';
+
+/**
+ * Fetches disease entity data from Monarch Initiative.
+ *
+ * Example: fetchDiseaseEntity('MONDO:0004976') returns ALS info
+ * including description, phenotypes, genes, hierarchy, and association counts.
+ *
+ * Endpoint: GET /v3/api/entity/{id}
+ */
+export async function fetchDiseaseEntity(id: string): Promise<MonarchEntity> {
+	const url = `${MONARCH_API_BASE_URL}/entity/${id}`;
+	const response = await fetch(url);
+
+	if (!response.ok) {
+		throw new Error(`Monarch API error: ${response.status} ${response.statusText} for entity ${id}`);
+	}
+
+	return response.json();
+}
+
+/**
+ * Fetches disease associations from Monarch Initiative.
+ *
+ * The "object" parameter is the disease ID — associations point TO this disease.
+ * For example, genes that CAUSE ALS: the gene is the subject, ALS is the object.
+ *
+ * For phenotype associations, the disease is the "subject" (disease HAS phenotype),
+ * so we use the "subject" parameter instead.
+ *
+ * Endpoint: GET /v3/api/association
+ */
+export async function fetchDiseaseAssociations(
+	diseaseId: string,
+	category: string,
+	limit: number = 20,
+	offset: number = 0,
+): Promise<MonarchAssociationResponse> {
+	// Phenotype associations use subject (disease → phenotype)
+	// Gene associations use object (gene → disease)
+	const isPhenotype = category.includes('DiseaseToPhenotypicFeature');
+	const entityParam = isPhenotype ? 'subject' : 'object';
+
+	const params = new URLSearchParams({
+		[entityParam]: diseaseId,
+		category,
+		limit: String(limit),
+		offset: String(offset),
+	});
+
+	const url = `${MONARCH_API_BASE_URL}/association?${params}`;
+	const response = await fetch(url);
+
+	if (!response.ok) {
+		throw new Error(`Monarch API error: ${response.status} ${response.statusText} for associations ${category}`);
+	}
+
+	return response.json();
+}

--- a/apps/stage/global/types/monarch.ts
+++ b/apps/stage/global/types/monarch.ts
@@ -1,0 +1,78 @@
+// Types for Monarch Initiative API v3 responses
+// Docs: https://api-v3.monarchinitiative.org/v3/docs
+
+// --- Entity endpoint: /v3/api/entity/{id} ---
+
+export interface AssociationCount {
+	label: string;
+	count: number;
+	category: string;
+}
+
+export interface HierarchyNode {
+	id: string;
+	name: string;
+	category: string;
+}
+
+export interface NodeHierarchy {
+	super_classes: HierarchyNode[];
+	sub_classes: HierarchyNode[];
+}
+
+export interface EntityMapping {
+	id: string;
+	url: string | null;
+}
+
+export interface MonarchEntity {
+	id: string;
+	name: string;
+	category: string;
+	description: string | null;
+	synonym: string[];
+	exact_synonym: string[];
+	namespace: string;
+	has_phenotype: string[];
+	has_phenotype_label: string[];
+	has_phenotype_count: number;
+	has_descendant: string[];
+	has_descendant_label: string[];
+	has_descendant_count: number;
+	causal_gene: string[];
+	inheritance: string | null;
+	mappings: EntityMapping[];
+	association_counts: AssociationCount[];
+	node_hierarchy: NodeHierarchy;
+}
+
+// --- Association endpoint: /v3/api/association ---
+
+export interface MonarchAssociation {
+	id: string;
+	category: string;
+	subject: string;
+	subject_label: string;
+	subject_namespace: string;
+	subject_category: string;
+	subject_taxon: string | null;
+	subject_taxon_label: string | null;
+	predicate: string;
+	object: string;
+	object_label: string;
+	object_namespace: string;
+	object_category: string;
+	object_closure_label: string[];
+	provided_by: string;
+	frequency_qualifier: string | null;
+	frequency_qualifier_label: string | null;
+	onset_qualifier: string | null;
+	onset_qualifier_label: string | null;
+}
+
+export interface MonarchAssociationResponse {
+	limit: number;
+	offset: number;
+	total: number;
+	items: MonarchAssociation[];
+}

--- a/apps/stage/global/utils/constants.ts
+++ b/apps/stage/global/utils/constants.ts
@@ -93,3 +93,14 @@ export const INTERNAL_API_PROXY = {
 	PROTECTED_KEYCLOAK_TOKEN_ENDPOINT: urlJoin(PROXY_PROTECTED_API_PATH, 'keycloak/token'),
 	SONG: urlJoin(PROXY_API_PATH, 'song'),
 } as const;
+
+// Monarch Initiative API
+export const MONARCH_API_BASE_URL = 'https://api-v3.monarchinitiative.org/v3/api';
+export const ALS_MONDO_ID = 'MONDO:0004976';
+
+export enum MONARCH_ASSOCIATION_CATEGORIES {
+	CAUSAL_GENE = 'biolink:CausalGeneToDiseaseAssociation',
+	CORRELATED_GENE = 'biolink:CorrelatedGeneToDiseaseAssociation',
+	PHENOTYPE = 'biolink:DiseaseToPhenotypicFeatureAssociation',
+	DISEASE = 'biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation',
+}


### PR DESCRIPTION
## Summary
Integrate Monarch Initiative API client: add TypeScript types, fetch service, and React hook for querying disease entity and association data from Monarch v3 API

## Changes
> All paths relative to `apps/stage/`

**New files:**
- `global/types/monarch.ts` — TypeScript interfaces for API responses (`MonarchEntity`, `MonarchAssociation`, `MonarchAssociationResponse`, etc.)
- `global/services/monarchApi.ts` — Fetch functions: `fetchDiseaseEntity()` and `fetchDiseaseAssociations()` using native `fetch()`
- `global/hooks/useMonarchData.ts` — React hook: auto-loads entity on mount, exposes `fetchAssociations()` on demand, manages loading/error states

**Modified files:**
- `global/utils/constants.ts` — Added `MONARCH_API_BASE_URL`, `ALS_MONDO_ID`, and `MONARCH_ASSOCIATION_CATEGORIES` enum

## Issues
Closes #3 