### PR TITLE
Build ALS Overview page. Create Disease Header section

### DIFF
--- a/apps/stage/components/pages/alsOverview/DiseaseHeader.tsx
+++ b/apps/stage/components/pages/alsOverview/DiseaseHeader.tsx
@@ -1,0 +1,119 @@
+import { css, useTheme } from '@emotion/react';
+import { ReactElement } from 'react';
+import { MonarchEntity } from '../../../global/types/monarch';
+import defaultTheme from '../../theme';
+
+interface DiseaseHeaderProps {
+	entity: MonarchEntity;
+}
+
+const DiseaseHeader = ({ entity }: DiseaseHeaderProps): ReactElement => {
+	const theme: typeof defaultTheme = useTheme();
+
+	return (
+		<header
+			id="overview"
+			css={css`
+				background: linear-gradient(135deg, ${theme.colors.primary_dark} 0%, ${theme.colors.primary} 100%);
+				color: ${theme.colors.white};
+				padding: 56px 40px;
+				scroll-margin-top: 80px;
+			`}
+		>
+			<div css={css`max-width: 860px; margin: 0 auto;`}>
+				<a
+					href={`https://monarchinitiative.org/disease/${entity.id}`}
+					target="_blank"
+					rel="noopener noreferrer"
+					css={css`
+						font-family: 'Geomanist', sans-serif;
+						font-size: 0.75rem;
+						font-weight: 700;
+						letter-spacing: 0.5px;
+						background: rgba(255, 255, 255, 0.15);
+						padding: 3px 12px;
+						border-radius: 12px;
+						display: inline-block;
+						margin-bottom: 18px;
+						color: ${theme.colors.white};
+						text-decoration: none;
+						transition: background 0.15s ease;
+
+						&:hover {
+							background: rgba(255, 255, 255, 0.25);
+						}
+					`}
+				>
+					{entity.id} ↗
+				</a>
+
+				{/* Disease name */}
+				<h1
+					css={css`
+						font-family: 'Geomanist', sans-serif;
+						font-size: 2.2rem;
+						font-weight: 700;
+						margin: 0 0 20px;
+						text-transform: capitalize;
+						line-height: 1.2;
+					`}
+				>
+					{entity.name}
+				</h1>
+
+				{/* Description */}
+				{entity.description && (
+					<p
+						css={css`
+							font-family: 'Geomanist', sans-serif;
+							font-size: 1rem;
+							font-weight: 300;
+							opacity: 0.9;
+							line-height: 1.7;
+							max-width: 760px;
+							margin: 0 0 28px;
+						`}
+					>
+						{entity.description}
+					</p>
+				)}
+
+				{/* Synonyms */}
+				{entity.synonym.length > 0 && (
+					<div css={css`display: flex; flex-wrap: wrap; gap: 8px; align-items: center;`}>
+						<span
+							css={css`
+								font-family: 'Geomanist', sans-serif;
+								font-size: 0.72rem;
+								font-weight: 700;
+								opacity: 0.65;
+								text-transform: uppercase;
+								letter-spacing: 0.6px;
+								flex-shrink: 0;
+							`}
+						>
+							Also known as
+						</span>
+						{entity.synonym.map((s) => (
+							<span
+								key={s}
+								css={css`
+									font-family: 'Geomanist', sans-serif;
+									font-size: 0.8rem;
+									font-weight: 300;
+									background: rgba(255, 255, 255, 0.15);
+									padding: 3px 10px;
+									border-radius: 12px;
+								`}
+							>
+								{s}
+							</span>
+						))}
+					</div>
+				)}
+			</div>
+		</header>
+	);
+};
+
+export default DiseaseHeader;

--- a/apps/stage/components/pages/alsOverview/index.tsx
+++ b/apps/stage/components/pages/alsOverview/index.tsx
@@ -1,22 +1,64 @@
-import { css } from '@emotion/react';
+import { css, useTheme } from '@emotion/react';
 import { ReactElement } from 'react';
 import PageLayout from '../../PageLayout';
+import defaultTheme from '../../theme';
+import { useMonarchData } from '../../../global/hooks/useMonarchData';
+import { ALS_MONDO_ID } from '../../../global/utils/constants';
+import DiseaseHeader from './DiseaseHeader';
+// import SideNav from './SideNav';                          // pending
+// import SummaryCards from './SummaryCards';                // pending
+// import PhenotypeOverview from './PhenotypeOverview';      // pending
+// import GenesTable from './GenesTable';                    // pending
+// import GeneToPhenotype from './GeneToPhenotype';          // pending
+// import DiseaseModels from './DiseaseModels';              // pending
+// import DiseaseHierarchy from './DiseaseHierarchy';        // pending
 
-const AlsOverview = (): ReactElement => (
-	<PageLayout subtitle="ALS Overview">
-		<div
-			css={css`
-				display: flex;
-				flex-direction: column;
-				align-items: center;
-				justify-content: center;
-				padding: 60px 20px;
-			`}
-		>
-			<h1>ALS Disease Overview</h1>
-			<p>This section will provide a comprehensive overview of Amyotrophic Lateral Sclerosis.</p>
-		</div>
-	</PageLayout>
-);
+const AlsOverview = (): ReactElement => {
+	const theme: typeof defaultTheme = useTheme();
+	const { entity, loading, error } = useMonarchData(ALS_MONDO_ID);
+
+	return (
+		<PageLayout subtitle="ALS Overview">
+			{/* Loading state */}
+			{loading && (
+				<div
+					css={css`
+						display: flex;
+						justify-content: center;
+						align-items: center;
+						padding: 120px 24px;
+						font-family: 'Geomanist', sans-serif;
+						font-size: 0.9rem;
+						color: ${theme.colors.grey_3};
+					`}
+				>
+					Loading ALS data…
+				</div>
+			)}
+
+			{/* Error state */}
+			{error && (
+				<div
+					css={css`
+						display: flex;
+						justify-content: center;
+						align-items: center;
+						padding: 120px 24px;
+						font-family: 'Geomanist', sans-serif;
+						font-size: 0.9rem;
+						color: ${theme.colors.error};
+					`}
+				>
+					Failed to load data: {error}
+				</div>
+			)}
+
+			{/* Main content */}
+			{entity && (
+				<DiseaseHeader entity={entity} />
+			)}
+		</PageLayout>
+	);
+};
 
 export default AlsOverview;


### PR DESCRIPTION
## Summary
Build the Disease Header section of the ALS Overview page, displaying the disease name, MONDO ID, description, and synonyms retrieved from the Monarch Initiative API

## Changes
> All paths relative to `apps/stage/`

**New files:**
- `components/pages/alsOverview/DiseaseHeader.tsx` — Disease Header component: full-width header with disease name, MONDO ID (linked to Monarch Initiative), description, and synonyms

**Modified files:**
- `components/pages/alsOverview/index.tsx` — Renders `DiseaseHeader` using data from the `useMonarchData hook

## Issues
Closes #4 