### PR TITLE
Build ALS Overview page. Create SideNav section

### DIFF
--- a/apps/stage/components/Footer.tsx
+++ b/apps/stage/components/Footer.tsx
@@ -4,6 +4,7 @@ import defaultTheme from './theme';
 const Footer = () => {
 	return (
 		<div
+			id="page-footer"
 			css={(theme: typeof defaultTheme) => css`
 				background-color: ${theme.colors.white};
 				box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.08);

--- a/apps/stage/components/pages/alsOverview/SideNav.tsx
+++ b/apps/stage/components/pages/alsOverview/SideNav.tsx
@@ -1,0 +1,97 @@
+import { css, useTheme } from '@emotion/react';
+import { ReactElement } from 'react';
+import defaultTheme from '../../theme';
+
+const NAV_HEIGHT = 72; // px — height of the top navbar
+
+const NAV_ITEMS = [
+	{ id: 'overview', label: 'Disease Overview' },
+	{ id: 'phenotypes', label: 'Phenotypes' },
+	{ id: 'causal-genes', label: 'Causal Genes' },
+	{ id: 'correlated-genes', label: 'Correlated Genes' },
+	{ id: 'gene-phenotype', label: 'Gene–Phenotype' },
+	{ id: 'disease-models', label: 'Disease Models' },
+	{ id: 'hierarchy', label: 'Disease Hierarchy' },
+];
+
+const scrollTo = (id: string) => (e: React.MouseEvent<HTMLAnchorElement>) => {
+	e.preventDefault();
+	document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
+};
+
+const SideNav = (): ReactElement => {
+	const theme: typeof defaultTheme = useTheme();
+
+	const linkCss = css`
+		display: block;
+		font-family: 'Geomanist', sans-serif;
+		font-size: 0.875rem;
+		font-weight: 300;
+		color: ${theme.colors.grey_6};
+		text-decoration: none;
+		padding: 10px 20px;
+		border-left: 2px solid transparent;
+		transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+
+		&:hover {
+			color: ${theme.colors.primary};
+			border-left-color: ${theme.colors.primary_pale};
+			background: ${theme.colors.primary_palest};
+		}
+	`;
+
+	return (
+		<nav
+			css={css`
+				width: 220px;
+				flex-shrink: 0;
+				position: sticky;
+				top: ${NAV_HEIGHT}px;
+				align-self: flex-start;
+				box-shadow: 3px 0 16px rgba(0, 0, 0, 0.07);
+				padding: 32px 0;
+				background: ${theme.colors.white};
+			`}
+		>
+			<p
+				css={css`
+					font-family: 'Geomanist', sans-serif;
+					font-size: 0.8rem;
+					font-weight: 700;
+					text-transform: uppercase;
+					letter-spacing: 0.8px;
+					color: ${theme.colors.grey_5};
+					margin: 0 0 8px;
+					padding: 0 20px;
+				`}
+			>
+				Contents
+			</p>
+
+			<ul css={css`list-style: none; margin: 0; padding: 0;`}>
+				{NAV_ITEMS.map((item) => (
+					<li key={item.id}>
+						<a href={`#${item.id}`} onClick={scrollTo(item.id)} css={linkCss}>
+							{item.label}
+						</a>
+					</li>
+				))}
+
+				{/* Separator + footer link */}
+				<li
+					css={css`
+						margin-top: 16px;
+						padding-top: 16px;
+						border-top: 1px solid ${theme.colors.grey_2};
+					`}
+				>
+					<a href="#page-footer" onClick={scrollTo('page-footer')} css={linkCss}>
+						Funding & Credits
+					</a>
+				</li>
+			</ul>
+		</nav>
+	);
+};
+
+export default SideNav;

--- a/apps/stage/components/pages/alsOverview/index.tsx
+++ b/apps/stage/components/pages/alsOverview/index.tsx
@@ -5,7 +5,7 @@ import defaultTheme from '../../theme';
 import { useMonarchData } from '../../../global/hooks/useMonarchData';
 import { ALS_MONDO_ID } from '../../../global/utils/constants';
 import DiseaseHeader from './DiseaseHeader';
-// import SideNav from './SideNav';                          // pending
+import SideNav from './SideNav';
 // import SummaryCards from './SummaryCards';                // pending
 // import PhenotypeOverview from './PhenotypeOverview';      // pending
 // import GenesTable from './GenesTable';                    // pending
@@ -53,9 +53,32 @@ const AlsOverview = (): ReactElement => {
 				</div>
 			)}
 
-			{/* Main content */}
 			{entity && (
-				<DiseaseHeader entity={entity} />
+				<>
+					{/* Full-width gradient header */}
+					<DiseaseHeader entity={entity} />
+
+					{/* Two-column layout: sidebar fixed left + content */}
+					<div
+						css={css`
+							display: flex;
+							width: 100%;
+							align-items: flex-start;
+						`}
+					>
+						<SideNav />
+
+						<main
+							css={css`
+								flex: 1;
+								min-width: 0;
+								padding: 40px 48px 72px;
+							`}
+						>
+							{/* sections will be added here as issues are completed */}
+						</main>
+					</div>
+				</>
 			)}
 		</PageLayout>
 	);


### PR DESCRIPTION
## Summary
Create the side navigation for the ALS Overview page with smooth scroll to each section

## Changes
> All paths relative to `apps/stage/`

**New files:**
- `components/pages/alsOverview/SideNav.tsx` — sticky side nav

**Modified files:**
- `components/pages/alsOverview/index.tsx` — two-column layout: SideNav on the left, main content area on the right
- `components/Footer.tsx` — added `id="page-footer"`

## Issues
Closes #5 