### PR TITLE
Build ALS Overview page. Create Summary Cards section

### DIFF
--- a/apps/stage/components/pages/alsOverview/SummaryCards.tsx
+++ b/apps/stage/components/pages/alsOverview/SummaryCards.tsx
@@ -1,0 +1,75 @@
+import { css, useTheme } from '@emotion/react';
+import { ReactElement } from 'react';
+import { AssociationCount } from '../../../global/types/monarch';
+import defaultTheme from '../../theme';
+
+const LABEL_MAP: Record<string, string> = {
+	'Disease to Phenotype': 'Phenotypes',
+	'Gene to Phenotype': 'Gene–Phenotype Links',
+	'Causal Gene': 'Causal Genes',
+	'Correlated Gene': 'Correlated Genes',
+	'Disease Model': 'Disease Models',
+};
+
+interface SummaryCardsProps {
+	associationCounts: AssociationCount[];
+}
+
+const SummaryCards = ({ associationCounts }: SummaryCardsProps): ReactElement => {
+	const theme: typeof defaultTheme = useTheme();
+
+	const counts = associationCounts.filter((ac) => LABEL_MAP[ac.label]);
+
+	return (
+		<div
+			css={css`
+				display: flex;
+				flex-wrap: wrap;
+				gap: 16px;
+				margin-bottom: 48px;
+			`}
+		>
+			{counts.map((ac) => (
+				<div
+					key={ac.category}
+					css={css`
+						background: ${theme.colors.white};
+						border: 1px solid ${theme.colors.grey_2};
+						border-radius: 10px;
+						padding: 20px 24px;
+						min-width: 130px;
+						flex: 1;
+					`}
+				>
+					<p
+						css={css`
+							font-family: 'Geomanist', sans-serif;
+							font-size: 1.9rem;
+							font-weight: 700;
+							color: ${theme.colors.primary};
+							margin: 0 0 4px;
+							line-height: 1;
+						`}
+					>
+						{ac.count.toLocaleString()}
+					</p>
+					<p
+						css={css`
+							font-family: 'Geomanist', sans-serif;
+							font-size: 0.75rem;
+							font-weight: 700;
+							text-transform: uppercase;
+							letter-spacing: 0.5px;
+							color: ${theme.colors.grey_3};
+							margin: 0;
+						`}
+					>
+						{LABEL_MAP[ac.label]}
+					</p>
+				</div>
+			))}
+		</div>
+	);
+};
+
+export default SummaryCards;

--- a/apps/stage/components/pages/alsOverview/index.tsx
+++ b/apps/stage/components/pages/alsOverview/index.tsx
@@ -6,7 +6,7 @@ import { useMonarchData } from '../../../global/hooks/useMonarchData';
 import { ALS_MONDO_ID } from '../../../global/utils/constants';
 import DiseaseHeader from './DiseaseHeader';
 import SideNav from './SideNav';
-// import SummaryCards from './SummaryCards';                // pending
+import SummaryCards from './SummaryCards';
 // import PhenotypeOverview from './PhenotypeOverview';      // pending
 // import GenesTable from './GenesTable';                    // pending
 // import GeneToPhenotype from './GeneToPhenotype';          // pending
@@ -55,10 +55,8 @@ const AlsOverview = (): ReactElement => {
 
 			{entity && (
 				<>
-					{/* Full-width gradient header */}
 					<DiseaseHeader entity={entity} />
 
-					{/* Two-column layout: sidebar fixed left + content */}
 					<div
 						css={css`
 							display: flex;
@@ -75,7 +73,7 @@ const AlsOverview = (): ReactElement => {
 								padding: 40px 48px 72px;
 							`}
 						>
-							{/* sections will be added here as issues are completed */}
+							<SummaryCards associationCounts={entity.association_counts} />
 						</main>
 					</div>
 				</>


### PR DESCRIPTION
## Summary
Create the summary cards section of the ALS Overview page, displaying association counts for the main ALS categories retrieved from the Monarch Initiative API

## Changes
> All paths relative to `apps/stage/`

**New files:**
- `components/pages/alsOverview/SummaryCards.tsx` — row of stat cards filters to 5 relevant categories (Phenotypes, Gene–Phenotype Links, Causal Genes, Correlated Genes, Disease Models)

**Modified files:**
- `components/pages/alsOverview/index.tsx` — renders SummaryCards in the main content area

## Issues
Closes #20 