### PR TITLE
Integrate EGA Metadata API

### DIFF
--- a/apps/stage/components/pages/apiTest/ega/index.tsx
+++ b/apps/stage/components/pages/apiTest/ega/index.tsx
@@ -1,0 +1,176 @@
+import { css } from '@emotion/react';
+import { useEffect, useState, ReactElement } from 'react';
+import PageLayout from '../../../PageLayout';
+import { useEgaData } from '../../../../global/hooks/useEgaData';
+import { fetchStudyDatasets } from '../../../../global/services/egaApi';
+import { EgaDataset } from '../../../../global/types/ega';
+import { EGA_API_BASE_URL, ALS_EGA_KEYWORDS } from '../../../../global/utils/constants';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const check = (condition: boolean) => (condition ? '✅' : '❌');
+
+const sectionCss = css`
+	margin-bottom: 32px;
+`;
+
+const titleCss = css`
+	font-size: 1rem;
+	font-weight: 700;
+	margin: 0 0 12px;
+	font-family: monospace;
+`;
+
+const rowCss = css`
+	font-family: monospace;
+	font-size: 0.85rem;
+	margin: 4px 0;
+	line-height: 1.5;
+`;
+
+const cardCss = css`
+	background: #f8f9fa;
+	border: 1px solid #dee2e6;
+	border-radius: 6px;
+	padding: 16px 20px;
+	margin-bottom: 8px;
+	font-family: monospace;
+	font-size: 0.8rem;
+	line-height: 1.6;
+`;
+
+const labelCss = css`
+	font-weight: 700;
+	color: #495057;
+`;
+
+const statusCss = (ok: boolean) => css`
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 4px;
+	font-size: 0.75rem;
+	font-weight: 700;
+	font-family: monospace;
+	background: ${ok ? '#d4edda' : '#f8d7da'};
+	color: ${ok ? '#155724' : '#721c24'};
+	margin-left: 8px;
+`;
+
+// ─── Main page ───────────────────────────────────────────────────────────────
+
+const EgaTest = (): ReactElement => {
+	const { studies, loading, error } = useEgaData();
+
+	const [datasets, setDatasets] = useState<EgaDataset[] | null>(null);
+	const [datasetsLoading, setDatasetsLoading] = useState(false);
+	const [datasetsError, setDatasetsError] = useState<string | null>(null);
+
+	// Once we have at least one ALS study, fetch its datasets
+	const firstStudy = studies[0] ?? null;
+
+	useEffect(() => {
+		if (!firstStudy) return;
+		setDatasetsLoading(true);
+		fetchStudyDatasets(firstStudy.accession_id)
+			.then((data) => {
+				setDatasets(data);
+				setDatasetsLoading(false);
+			})
+			.catch((err) => {
+				setDatasetsError(err instanceof Error ? err.message : 'Unknown error');
+				setDatasetsLoading(false);
+			});
+	}, [firstStudy]);
+
+	return (
+		<PageLayout subtitle="API Test — EGA">
+			<div
+				css={css`
+					max-width: 900px;
+					margin: 0 auto;
+					padding: 40px 24px 72px;
+				`}
+			>
+				<h1 css={css`font-family: monospace; font-size: 1.4rem; margin-bottom: 8px;`}>
+					EGA Metadata API — Integration Test
+				</h1>
+				<p css={css`font-family: monospace; font-size: 0.85rem; color: #6c757d; margin-bottom: 8px;`}>
+					Real HTTP requests to <code>{EGA_API_BASE_URL}</code>
+				</p>
+				<p css={css`font-family: monospace; font-size: 0.85rem; color: #6c757d; margin-bottom: 40px;`}>
+					ALS keywords: {ALS_EGA_KEYWORDS.map((kw) => <code key={kw} css={css`margin-right: 6px;`}>"{kw}"</code>)}
+				</p>
+
+				{/* ── Section 1: All studies + ALS filter ── */}
+				<div css={sectionCss}>
+					<p css={titleCss}>
+						GET /studies?limit=0 → ALS filter
+						{!loading && !error && <span css={statusCss(studies.length > 0)}>
+							{studies.length > 0 ? 'OK' : 'NO RESULTS'}
+						</span>}
+						{!loading && error && <span css={statusCss(false)}>FAIL</span>}
+					</p>
+
+					{loading && <p css={rowCss}>⏳ fetching all studies and filtering ALS…</p>}
+					{error && <p css={rowCss}>❌ Error: {error}</p>}
+
+					{!loading && !error && (
+						<>
+							<p css={rowCss}>{check(studies.length > 0)} ALS studies found: <strong>{studies.length}</strong></p>
+
+							{studies.slice(0, 3).map((study) => (
+								<div key={study.accession_id} css={cardCss}>
+									<span css={labelCss}>accession: </span>{study.accession_id}{' '}
+									<span css={labelCss}>type: </span>{study.study_type ?? '—'}{' '}
+									<span css={labelCss}>released: </span>{study.released_date?.slice(0, 10) ?? '—'}
+									<br />
+									<span css={labelCss}>title: </span>{study.title ?? '—'}
+								</div>
+							))}
+						</>
+					)}
+				</div>
+
+				<hr css={css`border: none; border-top: 1px solid #dee2e6; margin: 32px 0;`} />
+
+				{/* ── Section 2: Datasets for first ALS study ── */}
+				{!loading && !error && firstStudy && (
+					<div css={sectionCss}>
+						<p css={titleCss}>
+							GET /studies/{firstStudy.accession_id}/datasets
+							{!datasetsLoading && !datasetsError && datasets !== null && (
+								<span css={statusCss(datasets.length > 0)}>
+									{datasets.length > 0 ? 'OK' : 'EMPTY'}
+								</span>
+							)}
+							{!datasetsLoading && datasetsError && <span css={statusCss(false)}>FAIL</span>}
+						</p>
+
+						{datasetsLoading && <p css={rowCss}>⏳ loading datasets…</p>}
+						{datasetsError && <p css={rowCss}>❌ Error: {datasetsError}</p>}
+
+						{datasets !== null && (
+							<>
+								<p css={rowCss}>{check(datasets.length > 0)} datasets found: <strong>{datasets.length}</strong></p>
+
+								{datasets.slice(0, 3).map((ds) => (
+									<div key={ds.accession_id} css={cardCss}>
+										<span css={labelCss}>accession: </span>{ds.accession_id}{' '}
+										<span css={labelCss}>access: </span>{ds.access_type}{' '}
+										<span css={labelCss}>samples: </span>{ds.num_samples}
+										<br />
+										<span css={labelCss}>technologies: </span>{ds.technologies.join(', ') || '—'}
+										<br />
+										<span css={labelCss}>title: </span>{ds.title ?? '—'}
+									</div>
+								))}
+							</>
+						)}
+					</div>
+				)}
+			</div>
+		</PageLayout>
+	);
+};
+
+export default EgaTest;

--- a/apps/stage/components/pages/apiTest/index.tsx
+++ b/apps/stage/components/pages/apiTest/index.tsx
@@ -14,7 +14,6 @@ const API_TESTS = [
 		label: 'EGA Metadata API',
 		description: 'Studies and datasets metadata endpoints',
 		href: '/api-test/ega',
-		disabled: true,
 	},
 ];
 
@@ -39,7 +38,7 @@ const ApiTestIndex = (): ReactElement => (
 				{API_TESTS.map((test) => (
 					<a
 						key={test.key}
-						href={test.disabled ? undefined : test.href}
+						href={test.href}
 						css={css`
 							display: block;
 							padding: 20px 24px;
@@ -48,8 +47,6 @@ const ApiTestIndex = (): ReactElement => (
 							border-radius: 8px;
 							text-decoration: none;
 							color: inherit;
-							opacity: ${test.disabled ? 0.45 : 1};
-							pointer-events: ${test.disabled ? 'none' : 'auto'};
 							transition: border-color 0.15s ease, background 0.15s ease;
 
 							&:hover {
@@ -60,11 +57,6 @@ const ApiTestIndex = (): ReactElement => (
 					>
 						<p css={css`font-family: monospace; font-size: 0.95rem; font-weight: 700; margin: 0 0 4px;`}>
 							{test.label}
-							{test.disabled && (
-								<span css={css`font-size: 0.72rem; font-weight: 400; margin-left: 8px; color: #6c757d;`}>
-									(pending)
-								</span>
-							)}
 						</p>
 						<p css={css`font-family: monospace; font-size: 0.8rem; color: #6c757d; margin: 0;`}>
 							{test.description}

--- a/apps/stage/global/hooks/useEgaData.ts
+++ b/apps/stage/global/hooks/useEgaData.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { fetchAlsStudies, fetchStudyDatasets } from '../services/egaApi';
+import { EgaStudy, EgaDataset } from '../types/ega';
+
+interface UseEgaDataResult {
+	studies: EgaStudy[];
+	loading: boolean;
+	error: string | null;
+	fetchStudyDatasets: (studyId: string) => Promise<EgaDataset[]>;
+}
+
+/**
+ * Hook that fetches ALS-related EGA studies on mount and provides
+ * a function to fetch datasets for a given study on demand.
+ */
+export function useEgaData(): UseEgaDataResult {
+	const [studies, setStudies] = useState<EgaStudy[]>([]);
+	const [loading, setLoading] = useState<boolean>(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let isMounted = true;
+
+		async function loadStudies() {
+			setLoading(true);
+			setError(null);
+
+			try {
+				const data = await fetchAlsStudies();
+				if (isMounted) {
+					setStudies(data);
+				}
+			} catch (err) {
+				if (isMounted) {
+					setError(err instanceof Error ? err.message : 'Failed to fetch EGA studies');
+				}
+			} finally {
+				if (isMounted) {
+					setLoading(false);
+				}
+			}
+		}
+
+		loadStudies();
+
+		return () => {
+			isMounted = false;
+		};
+	}, []);
+
+	const fetchDatasets = useCallback((studyId: string) => {
+		return fetchStudyDatasets(studyId);
+	}, []);
+
+	return { studies, loading, error, fetchStudyDatasets: fetchDatasets };
+}

--- a/apps/stage/global/services/egaApi.ts
+++ b/apps/stage/global/services/egaApi.ts
@@ -1,0 +1,57 @@
+import { ALS_EGA_KEYWORDS } from '../utils/constants';
+import { EgaStudy, EgaDataset } from '../types/ega';
+
+// Local Next.js api requests to avoid CORS
+const EGA_PROXY_STUDIES = '/api/ega/studies';
+const EGA_PROXY_STUDY_DATASETS = '/api/ega/study-datasets';
+
+/**
+ * Fetches all public studies from EGA via server-side proxy.
+ */
+export async function fetchAllStudies(): Promise<EgaStudy[]> {
+	const response = await fetch(EGA_PROXY_STUDIES);
+
+	if (!response.ok) {
+		throw new Error(`EGA API error: ${response.status} ${response.statusText} for /studies`);
+	}
+
+	return response.json();
+}
+
+/**
+ * Filters studies where title, description, or abstract contains any ALS keyword.
+ * Also excludes deprecated studies and unreleased studies.
+ */
+export function filterAlsStudies(studies: EgaStudy[]): EgaStudy[] {
+	return studies.filter((study) => {
+		if (study.is_deprecated || !study.is_released) return false;
+
+		const alsSearchText = [study.title, study.description, study.abstract]
+			.filter(Boolean)
+			.join(' ')
+			.toLowerCase();
+
+		return ALS_EGA_KEYWORDS.some((kw) => alsSearchText.includes(kw));
+	});
+}
+
+/**
+ * Fetches all public studies and returns only those related to ALS.
+ */
+export async function fetchAlsStudies(): Promise<EgaStudy[]> {
+	const all = await fetchAllStudies();
+	return filterAlsStudies(all);
+}
+
+/**
+ * Fetches all datasets belonging to a specific study via server-side proxy.
+ */
+export async function fetchStudyDatasets(studyId: string): Promise<EgaDataset[]> {
+	const response = await fetch(`${EGA_PROXY_STUDY_DATASETS}/${studyId}`);
+
+	if (!response.ok) {
+		throw new Error(`EGA API error: ${response.status} ${response.statusText} for /studies/${studyId}/datasets`);
+	}
+
+	return response.json();
+}

--- a/apps/stage/global/types/ega.ts
+++ b/apps/stage/global/types/ega.ts
@@ -1,0 +1,30 @@
+
+// Studies
+export interface EgaStudy {
+	accession_id: string;
+	title: string | null;
+	abstract: string | null;
+	description: string | null;
+	study_type: string | null;
+	pubmed_ids: string | null;
+	external_links: string | null;
+	is_released: boolean;
+	released_date: string | null;
+	is_deprecated: boolean;
+}
+
+// Datasets
+export interface EgaDataset {
+	accession_id: string;
+	title: string | null;
+	description: string | null;
+	dataset_types: string[] | null;
+	technologies: string[];
+	num_samples: number;
+	access_type: string;
+	is_in_beacon: boolean;
+	is_released: boolean;
+	released_date: string | null;
+	is_deprecated: boolean;
+	policy_accession_id: string | null;
+}

--- a/apps/stage/global/types/ega.ts
+++ b/apps/stage/global/types/ega.ts
@@ -1,5 +1,4 @@
 
-// Studies
 export interface EgaStudy {
 	accession_id: string;
 	title: string | null;
@@ -13,7 +12,6 @@ export interface EgaStudy {
 	is_deprecated: boolean;
 }
 
-// Datasets
 export interface EgaDataset {
 	accession_id: string;
 	title: string | null;

--- a/apps/stage/global/utils/constants.ts
+++ b/apps/stage/global/utils/constants.ts
@@ -98,6 +98,10 @@ export const INTERNAL_API_PROXY = {
 export const MONARCH_API_BASE_URL = 'https://api-v3.monarchinitiative.org/v3/api';
 export const ALS_MONDO_ID = 'MONDO:0004976';
 
+// EGA Metadata API
+export const EGA_API_BASE_URL = 'https://metadata.ega-archive.org';
+export const ALS_EGA_KEYWORDS = ['als', 'amyotrophic', 'motor neuron disease'];
+
 export enum ALS_ASSOCIATION_CATEGORIES {
 	CAUSAL_GENE_TO_DISEASE = 'biolink:CausalGeneToDiseaseAssociation',
 	CORRELATED_GENE_TO_DISEASE = 'biolink:CorrelatedGeneToDiseaseAssociation',

--- a/apps/stage/pages/api-test/ega/index.tsx
+++ b/apps/stage/pages/api-test/ega/index.tsx
@@ -1,0 +1,8 @@
+import EgaTest from '@/components/pages/apiTest/ega';
+import { createPage } from '../../../global/utils/pages';
+
+const EgaTestPage = createPage({
+	isPublic: true,
+})(() => <EgaTest />);
+
+export default EgaTestPage;

--- a/apps/stage/pages/api/ega/studies.ts
+++ b/apps/stage/pages/api/ega/studies.ts
@@ -1,0 +1,38 @@
+import { EGA_API_BASE_URL } from '@/global/utils/constants';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const PAGE_SIZE = 500;
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+	try {
+		const allStudies: unknown[] = [];
+		let offset = 0;
+
+		while (true) {
+			const response = await fetch(
+				`${EGA_API_BASE_URL}/studies?limit=${PAGE_SIZE}&offset=${offset}`,
+			);
+
+			if (!response.ok) {
+				return res
+					.status(response.status)
+					.json({ error: `EGA API error: ${response.statusText}` });
+			}
+
+			const page: unknown[] = await response.json();
+
+			if (!Array.isArray(page) || page.length === 0) break;
+
+			allStudies.push(...page);
+			offset += page.length;
+
+			// If we got fewer than PAGE_SIZE we've reached the end
+			if (page.length < PAGE_SIZE) break;
+		}
+
+		return res.status(200).json(allStudies);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : 'Unknown error';
+		return res.status(500).json({ error: message });
+	}
+}

--- a/apps/stage/pages/api/ega/studies.ts
+++ b/apps/stage/pages/api/ega/studies.ts
@@ -5,12 +5,23 @@ const PAGE_SIZE = 500;
 
 export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
 	try {
-		const allStudies: unknown[] = [];
-		let offset = 0;
+		// Get the total number of studies from the HEAD request
+		const headResponse = await fetch(`${EGA_API_BASE_URL}/studies`, { method: 'HEAD' });
 
-		while (true) {
+		if (!headResponse.ok) {
+			return res
+				.status(headResponse.status)
+				.json({ error: `EGA API error: ${headResponse.statusText}` });
+		}
+
+		const totalCount = parseInt(headResponse.headers.get('ega-api-total-count') ?? '0', 10);
+		const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+
+		const allStudies: unknown[] = [];
+
+		for (let page = 0; page < totalPages; page++) {
 			const response = await fetch(
-				`${EGA_API_BASE_URL}/studies?limit=${PAGE_SIZE}&offset=${offset}`,
+				`${EGA_API_BASE_URL}/studies?limit=${PAGE_SIZE}&offset=${page * PAGE_SIZE}`,
 			);
 
 			if (!response.ok) {
@@ -19,15 +30,11 @@ export default async function handler(_req: NextApiRequest, res: NextApiResponse
 					.json({ error: `EGA API error: ${response.statusText}` });
 			}
 
-			const page: unknown[] = await response.json();
+			const pageData: unknown[] = await response.json();
 
-			if (!Array.isArray(page) || page.length === 0) break;
+			if (!Array.isArray(pageData)) break;
 
-			allStudies.push(...page);
-			offset += page.length;
-
-			// If we got fewer than PAGE_SIZE we've reached the end
-			if (page.length < PAGE_SIZE) break;
+			allStudies.push(...pageData);
 		}
 
 		return res.status(200).json(allStudies);

--- a/apps/stage/pages/api/ega/study-datasets/[studyId].ts
+++ b/apps/stage/pages/api/ega/study-datasets/[studyId].ts
@@ -1,0 +1,24 @@
+import { EGA_API_BASE_URL } from '@/global/utils/constants';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	const { studyId } = req.query;
+
+	if (!studyId || typeof studyId !== 'string') {
+		return res.status(400).json({ error: 'Missing studyId' });
+	}
+
+	try {
+		const response = await fetch(`${EGA_API_BASE_URL}/studies/${studyId}/datasets`);
+
+		if (!response.ok) {
+			return res.status(response.status).json({ error: `EGA API error: ${response.statusText}` });
+		}
+
+		const data = await response.json();
+		return res.status(200).json(data);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : 'Unknown error';
+		return res.status(500).json({ error: message });
+	}
+}


### PR DESCRIPTION
## Summary
Integrate EGA Metadata API and include a test page to ensure it works properly

## Changes
> All paths relative to `apps/stage/`

**New files:**
- `global/types/ega.ts` — TypeScript interfaces for API responses (`EgaStudy`, `EgaDataset`)
- `global/services/egaApi.ts` — Fetch functions: `fetchAllStudies()`, `filterAlsStudies()`, `fetchAlsStudies()`, and `fetchStudyDatasets()` using native `fetch()` via local proxy
- `global/hooks/useEgaData.ts` — React hook: auto-loads ALS studies on mount, exposes `fetchStudyDatasets()` on demand, manages loading/error states
- `pages/api/ega/studies.ts` — Server-side proxy route: paginates through all EGA studies and returns them to the client
- `pages/api/ega/study-datasets/[studyId].ts` — Server-side proxy route: fetches datasets for a given study
- `components/pages/apiTest/ega/index.tsx` — Integration test page: validates studies endpoint and datasets endpoint with live requests
- `pages/api-test/ega/index.tsx` — Next.js page wrapper for the EGA test page

**Modified files:**
- `global/utils/constants.ts` — Added `EGA_API_BASE_URL` and `ALS_EGA_KEYWORDS`
- `components/pages/apiTest/index.tsx` — Enabled EGA test link (removed `disabled` flag)

## Issues
Closes #6 