### PR TITLE
Add reset policies to Docker services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     profiles: ["demo", "default"]
     image: alpine/curl:8.8.0
     container_name: setup
+    restart: unless-stopped
     ports:
       - "9204:9204"
     volumes:
@@ -84,6 +85,7 @@ services:
       dockerfile: Dockerfile
     image: conductor-cli:1.0
     container_name: conductor-cli
+    restart: unless-stopped
     pull_policy: never
     volumes:
       - ./data:/data
@@ -115,6 +117,7 @@ services:
     profiles: ["demo", "default"]
     image: postgres:15-alpine
     container_name: postgres
+    restart: unless-stopped
     platform: linux/amd64
     ports:
       - "5435:5432"
@@ -143,6 +146,7 @@ services:
     profiles: ["demo", "demo", "default"]
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.27
     container_name: elasticsearch
+    restart: unless-stopped
     platform: linux/amd64
     ports:
       - "9200:9200"
@@ -181,6 +185,7 @@ services:
     profiles: ["demo", "demo", "default"]
     image: ghcr.io/overture-stack/arranger-server:3.0.0-beta.36
     container_name: arranger-datatable1
+    restart: unless-stopped
     platform: linux/amd64
     depends_on:
       setup:
@@ -215,6 +220,7 @@ services:
       dockerfile: ./apps/stage/Dockerfile
     image: stageimage:1.0
     container_name: stage
+    restart: unless-stopped
     platform: linux/amd64
     depends_on:
       setup:
@@ -248,6 +254,7 @@ volumes:
   elasticsearch-data:
   stage-data:
   postgres-data:
+
 networks:
   platform-network:
     driver: bridge


### PR DESCRIPTION
## Summary
Add restart policies to all Docker services to prevent downtime

## Changes
> All paths relative to project root

**Modified files:**
- `docker-compose.yml` — Added `restart: unless-stopped` to all services (`setup`, `conductor-cli`, `postgres`, `elasticsearch`, `arranger-datatable1`, `stage`) to ensure containers restart automatically on failure or host reboot.

## Issues
Closes #46 