### PR TITLE
Emphasize blue color transition

### DIFF
--- a/apps/stage/components/PageLayout.tsx
+++ b/apps/stage/components/PageLayout.tsx
@@ -20,7 +20,7 @@ const PageLayout = ({ children, subtitle }: { children: ReactNode; subtitle?: st
 					color: ${theme.colors.black};
 					width: 100%;
 					max-width: 100%;
-					overflow-x: hidden;
+					overflow-x: clip;
 					padding-top: ${theme.dimensions.navbar.height}px;
 				`}
 			>

--- a/apps/stage/components/pages/alsOverview/DiseaseHeader.tsx
+++ b/apps/stage/components/pages/alsOverview/DiseaseHeader.tsx
@@ -14,7 +14,7 @@ const DiseaseHeader = ({ entity }: DiseaseHeaderProps): ReactElement => {
 		<header
 			id="overview"
 			css={css`
-				background: linear-gradient(135deg, ${theme.colors.primary_dark} 0%, ${theme.colors.primary} 100%);
+				background: linear-gradient(135deg, ${theme.colors.primary_darker} 10%, ${theme.colors.primary} 50%, ${theme.colors.primary_lightest} 100%);
 				color: ${theme.colors.white};
 				padding: 56px 40px;
 				scroll-margin-top: 80px;

--- a/apps/stage/components/pages/dataSources/index.tsx
+++ b/apps/stage/components/pages/dataSources/index.tsx
@@ -60,7 +60,7 @@ const DataSources = (): ReactElement => {
 			{/* Page header */}
 			<section
 				css={css`
-					background: linear-gradient(135deg, ${theme.colors.primary_dark} 0%, ${theme.colors.primary} 100%);
+					background: linear-gradient(135deg, ${theme.colors.primary_darker} 10%, ${theme.colors.primary} 50%, ${theme.colors.primary_lightest} 100%);
 					color: ${theme.colors.white};
 					padding: 56px 24px;
 					text-align: center;

--- a/apps/stage/components/pages/diseaseModel/index.tsx
+++ b/apps/stage/components/pages/diseaseModel/index.tsx
@@ -11,7 +11,7 @@ const DiseaseModel = (): ReactElement => {
 			{/* Page header */}
 			<section
 				css={css`
-					background: linear-gradient(135deg, ${theme.colors.primary_dark} 0%, ${theme.colors.primary} 100%);
+					background: linear-gradient(135deg, ${theme.colors.primary_darker} 10%, ${theme.colors.primary} 50%, ${theme.colors.primary_lightest} 100%);
 					color: ${theme.colors.white};
 					padding: 56px 24px;
 					text-align: center;

--- a/apps/stage/components/pages/egaExplorer/index.tsx
+++ b/apps/stage/components/pages/egaExplorer/index.tsx
@@ -248,7 +248,7 @@ const EgaExplorer = (): ReactElement => {
 					{/* Page header */}
 					<section
 						css={css`
-							background: linear-gradient(135deg, ${theme.colors.primary_dark} 0%, ${theme.colors.primary} 100%);
+							background: linear-gradient(135deg, ${theme.colors.primary_darker} 10%, ${theme.colors.primary} 50%, ${theme.colors.primary_lightest} 100%);
 							color: ${theme.colors.white};
 							padding: 56px 24px;
 							text-align: center;


### PR DESCRIPTION
## Summary
Emphasize blue gradient on page headers to match home page style

## Changes
> All paths relative to `apps/stage/`

**Modified files:**
- `components/PageLayout.tsx` — change `overflow-x: hidden` to `overflow-x: clip` to restore `position: sticky` on sidebars
- `components/pages/alsOverview/DiseaseHeader.tsx` — update header gradient to match Home page
- `components/pages/egaExplorer/index.tsx` — update header gradient to match Home page
- `components/pages/diseaseModel/index.tsx` — update header gradient to match Home page
- `components/pages/dataSources/index.tsx` — update header gradient to match Home page

## Issues
Closes #42