### PR TITLE
Add new features on ALS Overview page

### DIFF
--- a/apps/stage/components/pages/alsOverview/DiseaseHierarchyFlow.tsx
+++ b/apps/stage/components/pages/alsOverview/DiseaseHierarchyFlow.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import ReactFlow, { Edge, Handle, MarkerType, Node, NodeMouseHandler, Position } from 'reactflow';
+import ReactFlow, { Controls, Edge, Handle, MarkerType, Node, NodeMouseHandler, Position } from 'reactflow';
 import 'reactflow/dist/style.css';
 import { HierarchyNode, NodeHierarchy } from '../../../global/types/monarch';
 
@@ -150,7 +150,9 @@ export default function DiseaseHierarchyFlow({ hierarchy, diseaseName, diseaseId
 				panOnScroll={false}
 				panOnDrag={true}
 				proOptions={{ hideAttribution: true }}
-			/>
+			>
+				<Controls showInteractive={false} />
+			</ReactFlow>
 		</div>
 	);
 }

--- a/apps/stage/components/pages/alsOverview/SummaryCards.tsx
+++ b/apps/stage/components/pages/alsOverview/SummaryCards.tsx
@@ -1,5 +1,5 @@
 import { css, useTheme } from '@emotion/react';
-import { ReactElement } from 'react';
+import { ReactElement, useEffect, useRef, useState } from 'react';
 import { AssociationCount } from '../../../global/types/monarch';
 import defaultTheme from '../../theme';
 
@@ -10,6 +10,90 @@ const LABEL_MAP: Record<string, string> = {
 	'Correlated Gene': 'Correlated Genes',
 	'Disease Model': 'Disease Models',
 };
+
+function useCountUp(target: number, duration = 1400) {
+	const [count, setCount] = useState(0);
+	const ref = useRef<HTMLParagraphElement>(null);
+	const started = useRef(false);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				if (entry.isIntersecting && !started.current) {
+					started.current = true;
+					const start = performance.now();
+					const step = (now: number) => {
+						const elapsed = now - start;
+						const progress = Math.min(elapsed / duration, 1);
+						const eased = 1 - Math.pow(1 - progress, 3);
+						setCount(Math.round(eased * target));
+						if (progress < 1) requestAnimationFrame(step);
+					};
+					requestAnimationFrame(step);
+				}
+			},
+			{ threshold: 0.3 },
+		);
+
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [target, duration]);
+
+	return { count, ref };
+}
+
+interface SummaryCardProps {
+	count: number;
+	label: string;
+	theme: typeof defaultTheme;
+}
+
+function SummaryCard({ count, label, theme }: SummaryCardProps): ReactElement {
+	const { count: animatedCount, ref } = useCountUp(count);
+
+	return (
+		<div
+			css={css`
+				background: ${theme.colors.white};
+				border: 1px solid ${theme.colors.grey_2};
+				border-radius: 10px;
+				padding: 20px 24px;
+				min-width: 130px;
+				flex: 1;
+			`}
+		>
+			<p
+				ref={ref}
+				css={css`
+					font-family: 'Geomanist', sans-serif;
+					font-size: 1.9rem;
+					font-weight: 700;
+					color: ${theme.colors.primary};
+					margin: 0 0 4px;
+					line-height: 1;
+				`}
+			>
+				{animatedCount.toLocaleString()}
+			</p>
+			<p
+				css={css`
+					font-family: 'Geomanist', sans-serif;
+					font-size: 0.75rem;
+					font-weight: 700;
+					text-transform: uppercase;
+					letter-spacing: 0.5px;
+					color: ${theme.colors.grey_3};
+					margin: 0;
+				`}
+			>
+				{label}
+			</p>
+		</div>
+	);
+}
 
 interface SummaryCardsProps {
 	associationCounts: AssociationCount[];
@@ -30,43 +114,12 @@ const SummaryCards = ({ associationCounts }: SummaryCardsProps): ReactElement =>
 			`}
 		>
 			{counts.map((ac) => (
-				<div
+				<SummaryCard
 					key={ac.category}
-					css={css`
-						background: ${theme.colors.white};
-						border: 1px solid ${theme.colors.grey_2};
-						border-radius: 10px;
-						padding: 20px 24px;
-						min-width: 130px;
-						flex: 1;
-					`}
-				>
-					<p
-						css={css`
-							font-family: 'Geomanist', sans-serif;
-							font-size: 1.9rem;
-							font-weight: 700;
-							color: ${theme.colors.primary};
-							margin: 0 0 4px;
-							line-height: 1;
-						`}
-					>
-						{ac.count.toLocaleString()}
-					</p>
-					<p
-						css={css`
-							font-family: 'Geomanist', sans-serif;
-							font-size: 0.75rem;
-							font-weight: 700;
-							text-transform: uppercase;
-							letter-spacing: 0.5px;
-							color: ${theme.colors.grey_3};
-							margin: 0;
-						`}
-					>
-						{LABEL_MAP[ac.label]}
-					</p>
-				</div>
+					count={ac.count}
+					label={LABEL_MAP[ac.label]}
+					theme={theme}
+				/>
 			))}
 		</div>
 	);


### PR DESCRIPTION
## Summary
Add counter animation to summary cards and controls to disease hierarchy chart on ALS Overview page

## Changes
> All paths relative to `apps/stage/`

**Modified files:**
- `components/pages/alsOverview/SummaryCards.tsx` — extract SummaryCard sub-component with a `useCountUp` hook that animates numbers from 0 to their target value using an IntersectionObserver (animation triggers on viewport entry, ease-out cubic easing)
- `components/pages/alsOverview/DiseaseHierarchyFlow.tsx` — add ReactFlow Controls component (zoom in, zoom out, fit view) to the disease hierarchy chart

## Issues
Closes #43