### PR TITLE
Filter EGA studies by ALS accession IDs

### DIFF
--- a/.github/scripts/update-ega-als-ids.js
+++ b/.github/scripts/update-ega-als-ids.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Queries the EGA Metadata API for ALS-related studies using keyword matching,
+ * compares results against the current accession ID list in constants.ts,
+ * and exits with code 1 if new IDs are found (signals the workflow to open a PR).
+ *
+ * New IDs are written to .github/scripts/new-als-ids.json for the workflow to read.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+const EGA_BASE = 'https://metadata.ega-archive.org';
+const KEYWORDS = ['als', 'amyotrophic', 'motor neuron disease'];
+const CONSTANTS_PATH = path.join(__dirname, '../../apps/stage/global/utils/constants.ts');
+const OUTPUT_PATH = path.join(__dirname, 'new-als-ids.json');
+
+function fetch(url) {
+	return new Promise((resolve, reject) => {
+		https.get(url, (res) => {
+			let data = '';
+			res.on('data', (chunk) => (data += chunk));
+			res.on('end', () => {
+				if (res.statusCode >= 400) {
+					reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+				} else {
+					resolve({ status: res.statusCode, headers: res.headers, body: data });
+				}
+			});
+		}).on('error', reject);
+	});
+}
+
+function matchesAls(study) {
+	if (study.is_deprecated || !study.is_released) return false;
+	const text = [study.title, study.description, study.abstract]
+		.filter(Boolean)
+		.join(' ')
+		.toLowerCase();
+	return KEYWORDS.some((kw) =>
+		kw === 'als' ? /\bals\b/.test(text) : text.includes(kw),
+	);
+}
+
+function getCurrentIds() {
+	const src = fs.readFileSync(CONSTANTS_PATH, 'utf8');
+	const match = src.match(/ALS_EGA_ACCESSION_IDS[^=]*=\s*\[([\s\S]*?)\];/);
+	if (!match) throw new Error('Could not find ALS_EGA_ACCESSION_IDS in constants.ts');
+	return [...match[1].matchAll(/'(EGAS\w+)'/g)].map((m) => m[1]);
+}
+
+async function main() {
+	console.log('Fetching total study count from EGA...');
+	const head = await fetch(`${EGA_BASE}/studies`);
+	const total = parseInt(head.headers['ega-api-total-count'] ?? '0', 10);
+	const PAGE_SIZE = 500;
+	const pages = Math.ceil(total / PAGE_SIZE);
+	console.log(`Total studies: ${total} (${pages} pages)`);
+
+	const allStudies = [];
+	for (let page = 0; page < pages; page++) {
+		const url = `${EGA_BASE}/studies?limit=${PAGE_SIZE}&offset=${page * PAGE_SIZE}`;
+		console.log(`Fetching page ${page + 1}/${pages}...`);
+		const res = await fetch(url);
+		allStudies.push(...JSON.parse(res.body));
+	}
+
+	const foundIds = allStudies.filter(matchesAls).map((s) => s.accession_id).sort();
+	console.log(`Found ${foundIds.length} ALS-related studies`);
+
+	const currentIds = getCurrentIds();
+	console.log(`Current list has ${currentIds.length} IDs`);
+
+	const currentSet = new Set(currentIds);
+	const newIds = foundIds.filter((id) => !currentSet.has(id));
+
+	if (newIds.length === 0) {
+		console.log('No new ALS studies found. List is up to date.');
+		process.exit(0);
+	}
+
+	console.log(`Found ${newIds.length} new ID(s): ${newIds.join(', ')}`);
+	fs.writeFileSync(OUTPUT_PATH, JSON.stringify(newIds, null, 2));
+	process.exit(1);
+}
+
+main().catch((err) => {
+	console.error('Error:', err.message);
+	process.exit(2);
+});

--- a/.github/scripts/update-ega-als-ids.js
+++ b/.github/scripts/update-ega-als-ids.js
@@ -16,9 +16,15 @@ const KEYWORDS = ['als', 'amyotrophic', 'motor neuron disease'];
 const CONSTANTS_PATH = path.join(__dirname, '../../apps/stage/global/utils/constants.ts');
 const OUTPUT_PATH = path.join(__dirname, 'new-als-ids.json');
 
-function fetch(url) {
+function fetch(url, method = 'GET') {
 	return new Promise((resolve, reject) => {
-		https.get(url, (res) => {
+		const urlObj = new URL(url);
+		const options = {
+			hostname: urlObj.hostname,
+			path: urlObj.pathname + urlObj.search,
+			method,
+		};
+		const req = https.request(options, (res) => {
 			let data = '';
 			res.on('data', (chunk) => (data += chunk));
 			res.on('end', () => {
@@ -28,7 +34,9 @@ function fetch(url) {
 					resolve({ status: res.statusCode, headers: res.headers, body: data });
 				}
 			});
-		}).on('error', reject);
+		});
+		req.on('error', reject);
+		req.end();
 	});
 }
 
@@ -52,7 +60,7 @@ function getCurrentIds() {
 
 async function main() {
 	console.log('Fetching total study count from EGA...');
-	const head = await fetch(`${EGA_BASE}/studies`);
+	const head = await fetch(`${EGA_BASE}/studies`, 'HEAD');
 	const total = parseInt(head.headers['ega-api-total-count'] ?? '0', 10);
 	const PAGE_SIZE = 500;
 	const pages = Math.ceil(total / PAGE_SIZE);

--- a/.github/workflows/update-ega-als-ids.yml
+++ b/.github/workflows/update-ega-als-ids.yml
@@ -1,0 +1,83 @@
+name: Update EGA ALS Accession IDs
+
+on:
+  schedule:
+    - cron: '0 8 1 * *'  # 1st of every month at 08:00 UTC
+  workflow_dispatch:      # allow manual trigger from GitHub UI
+
+jobs:
+  check-new-als-studies:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run EGA ALS ID detection script
+        id: detect
+        run: node .github/scripts/update-ega-als-ids.js
+        continue-on-error: true
+
+      - name: Update constants.ts with new IDs
+        if: steps.detect.outcome == 'failure'
+        run: |
+          NEW_IDS=$(node -e "
+            const fs = require('fs');
+            const newIds = JSON.parse(fs.readFileSync('.github/scripts/new-als-ids.json', 'utf8'));
+            const src = fs.readFileSync('apps/stage/global/utils/constants.ts', 'utf8');
+            const match = src.match(/ALS_EGA_ACCESSION_IDS[^=]*=\s*\[([\s\S]*?)\];/);
+            const current = [...match[1].matchAll(/'(EGAS\w+)'/g)].map(m => m[1]);
+            const merged = [...new Set([...current, ...newIds])].sort();
+            const entries = merged.map(id => \`\t'\${id}',\`).join('\n');
+            const updated = src.replace(
+              /ALS_EGA_ACCESSION_IDS[^=]*=\s*\[([\s\S]*?)\];/,
+              \`ALS_EGA_ACCESSION_IDS: string[] = [\n\${entries}\n];\`
+            );
+            fs.writeFileSync('apps/stage/global/utils/constants.ts', updated);
+            console.log(newIds.join(', '));
+          ")
+          echo "NEW_IDS=$NEW_IDS" >> $GITHUB_ENV
+
+      - name: Commit and push changes
+        if: steps.detect.outcome == 'failure'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b bot/update-ega-als-ids
+          git add apps/stage/global/utils/constants.ts
+          git commit -m "update ALS EGA accession IDs list"
+          git push origin bot/update-ega-als-ids --force
+
+      - name: Open pull request (skip if already exists)
+        if: steps.detect.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh pr list --head bot/update-ega-als-ids --base TechBioLab --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already exists, skipping creation."
+          else
+            gh pr create \
+              --title "[Bot] New ALS studies detected in EGA" \
+              --body "## New ALS studies detected
+
+          The monthly EGA scan found new ALS-related studies not present in the current accession ID list.
+
+          **New IDs added:** \`${{ env.NEW_IDS }}\`
+
+          Please review and merge if the studies are relevant.
+
+          ---
+          *Opened automatically by the [Update EGA ALS Accession IDs](.github/workflows/update-ega-als-ids.yml) workflow.*" \
+              --base TechBioLab \
+              --label "automated" \
+              --label "data-update"
+          fi

--- a/apps/stage/global/services/egaApi.ts
+++ b/apps/stage/global/services/egaApi.ts
@@ -1,48 +1,20 @@
-import { ALS_EGA_KEYWORDS } from '../utils/constants';
 import { EgaStudy, EgaDataset } from '../types/ega';
 
-// Local Next.js api requests to avoid CORS
 const EGA_PROXY_STUDIES = '/api/ega/studies';
 const EGA_PROXY_STUDY_DATASETS = '/api/ega/study-datasets';
 
 /**
- * Fetches all public studies from EGA via server-side proxy.
+ * Fetches ALS studies from the server-side proxy.
+ * The proxy resolves the predefined accession ID list directly against the EGA API.
  */
-export async function fetchAllStudies(): Promise<EgaStudy[]> {
+export async function fetchAlsStudies(): Promise<EgaStudy[]> {
 	const response = await fetch(EGA_PROXY_STUDIES);
 
 	if (!response.ok) {
-		throw new Error(`EGA API error: ${response.status} ${response.statusText} for /studies`);
+		throw new Error(`EGA API error: ${response.status} ${response.statusText}`);
 	}
 
 	return response.json();
-}
-
-/**
- * Filters studies where title, description, or abstract contains any ALS keyword.
- * Also excludes deprecated studies and unreleased studies.
- */
-export function filterAlsStudies(studies: EgaStudy[]): EgaStudy[] {
-	return studies.filter((study) => {
-		if (study.is_deprecated || !study.is_released) return false;
-
-		const alsSearchText = [study.title, study.description, study.abstract]
-			.filter(Boolean)
-			.join(' ')
-			.toLowerCase();
-
-		return ALS_EGA_KEYWORDS.some((kw) =>
-		kw === 'als' ? /\bals\b/i.test(alsSearchText) : alsSearchText.includes(kw),
-	);
-	});
-}
-
-/**
- * Fetches all public studies and returns only those related to ALS.
- */
-export async function fetchAlsStudies(): Promise<EgaStudy[]> {
-	const all = await fetchAllStudies();
-	return filterAlsStudies(all);
 }
 
 /**

--- a/apps/stage/global/utils/constants.ts
+++ b/apps/stage/global/utils/constants.ts
@@ -102,6 +102,36 @@ export const ALS_MONDO_ID = 'MONDO:0004976';
 export const EGA_API_BASE_URL = 'https://metadata.ega-archive.org';
 export const ALS_EGA_KEYWORDS = ['als', 'amyotrophic', 'motor neuron disease'];
 
+// Predefined list of ALS-related study accession IDs from EGA.
+// Maintained automatically by the GitHub Actions workflow (.github/workflows/update-ega-als-ids.yml).
+export const ALS_EGA_ACCESSION_IDS: string[] = [
+	'EGAS00001002439',
+	'EGAS00001002462',
+	'EGAS00001002473',
+	'EGAS00001002598',
+	'EGAS00001003295',
+	'EGAS00001003383',
+	'EGAS00001004286',
+	'EGAS00001004587',
+	'EGAS00001005220',
+	'EGAS00001005879',
+	'EGAS00001005880',
+	'EGAS00001005881',
+	'EGAS00001006138',
+	'EGAS00001006675',
+	'EGAS00001006711',
+	'EGAS00001007318',
+	'EGAS00001008053',
+	'EGAS50000000575',
+	'EGAS50000000908',
+	'EGAS50000000909',
+	'EGAS50000001019',
+	'EGAS50000001267',
+	'EGAS50000001562',
+	'EGAS50000001563',
+	'EGAS50000001566',
+];
+
 export enum ALS_ASSOCIATION_CATEGORIES {
 	CAUSAL_GENE_TO_DISEASE = 'biolink:CausalGeneToDiseaseAssociation',
 	CORRELATED_GENE_TO_DISEASE = 'biolink:CorrelatedGeneToDiseaseAssociation',

--- a/apps/stage/pages/api/ega/studies.ts
+++ b/apps/stage/pages/api/ega/studies.ts
@@ -1,43 +1,17 @@
-import { EGA_API_BASE_URL } from '@/global/utils/constants';
+import { ALS_EGA_ACCESSION_IDS, EGA_API_BASE_URL } from '@/global/utils/constants';
 import type { NextApiRequest, NextApiResponse } from 'next';
-
-const PAGE_SIZE = 500;
 
 export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
 	try {
-		// Get the total number of studies from the HEAD request
-		const headResponse = await fetch(`${EGA_API_BASE_URL}/studies`, { method: 'HEAD' });
+		const results = await Promise.all(
+			ALS_EGA_ACCESSION_IDS.map(async (id) => {
+				const r = await fetch(`${EGA_API_BASE_URL}/studies/${id}`);
+				if (!r.ok) return null;
+				return r.json();
+			}),
+		);
 
-		if (!headResponse.ok) {
-			return res
-				.status(headResponse.status)
-				.json({ error: `EGA API error: ${headResponse.statusText}` });
-		}
-
-		const totalCount = parseInt(headResponse.headers.get('ega-api-total-count') ?? '0', 10);
-		const totalPages = Math.ceil(totalCount / PAGE_SIZE);
-
-		const allStudies: unknown[] = [];
-
-		for (let page = 0; page < totalPages; page++) {
-			const response = await fetch(
-				`${EGA_API_BASE_URL}/studies?limit=${PAGE_SIZE}&offset=${page * PAGE_SIZE}`,
-			);
-
-			if (!response.ok) {
-				return res
-					.status(response.status)
-					.json({ error: `EGA API error: ${response.statusText}` });
-			}
-
-			const pageData: unknown[] = await response.json();
-
-			if (!Array.isArray(pageData)) break;
-
-			allStudies.push(...pageData);
-		}
-
-		return res.status(200).json(allStudies);
+		return res.status(200).json(results.filter(Boolean));
 	} catch (err) {
 		const message = err instanceof Error ? err.message : 'Unknown error';
 		return res.status(500).json({ error: message });


### PR DESCRIPTION
## Summary
Add predefined ALS accession ID list and GitHub Actions workflow to detect and update new EGA studies monthly

## Changes
**Modified files:**
- `apps/stage/global/utils/constants.ts` — add `ALS_EGA_ACCESSION_IDS` list with 25 predefined ALS study accession IDs
- `apps/stage/global/services/egaApi.ts` — replace keyword filtering with ID-based lookup; simplify `fetchAlsStudies()` (filtering now handled server-side)
- `apps/stage/pages/api/ega/studies.ts` — rewrite proxy to fetch only the 25 known studies by ID in parallel instead of paginating all ~10,000 EGA studies

**New files:**
- `.github/scripts/update-ega-als-ids.js` — Node.js script that queries EGA, filters by ALS keywords, compares with current ID list, and exits with code 1 if new IDs are found
- `.github/workflows/update-ega-als-ids.yml` — GitHub Actions workflow (runs 1st of every month + manual trigger) that runs the detection script and opens a PR if new studies are detected

## Issues
Closes #48