### PR TITLE
Update restart policies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     profiles: ["demo", "default"]
     image: alpine/curl:8.8.0
     container_name: setup
-    restart: unless-stopped
+    restart: on-failure
     ports:
       - "9204:9204"
     volumes:


### PR DESCRIPTION
## Summary
Fix setup service restart policy from unless-stopped to on-failure

## Changes

**Modified files:**
- `docker-compose.yml` — change `restart: unless-stopped` to `restart: on-failure` for the setup service

## Issues
Closes #60