### PR TITLE
Production Docker Compose configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ help:
 	@echo "  demo           - Start demo deployment (with data)"
 	@echo ""
 	@echo "  stage-dev      - Start Stage development environment"
+	@echo "  prod           - Start production deployment (stage only)"
+	@echo "  prod-down      - Stop production deployment"
 	@echo ""
 	@echo "System Management:"
 	@echo "  down           - Gracefully shutdown all containers"
@@ -26,6 +28,17 @@ phase0:
 	@echo "Running Pre-deployment checks..."
 	chmod +x ./setup/scripts/deployments/phase0.sh
 	./setup/scripts/deployments/phase0.sh 
+
+# Start production deployment (stage only)
+prod:
+	@echo "Building and starting production stage..."
+	docker compose -f docker-compose.prod.yml build stage
+	docker compose -f docker-compose.prod.yml up -d
+
+# Stop production deployment
+prod-down:
+	@echo "Stopping production stage..."
+	docker compose -f docker-compose.prod.yml down
 
 # Start demo deployment (populates portal with data for you)
 demo: phase0

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,35 @@
+services:
+  stage:
+    build:
+      context: .
+      dockerfile: ./apps/stage/Dockerfile
+    image: stageimage:1.0
+    container_name: stage
+    restart: unless-stopped
+    platform: linux/amd64
+    ports:
+      - "3000:3000"
+    environment:
+      # TODO: set to your production domain (e.g. https://seed-als.bsc.es/api/auth)
+      NEXTAUTH_URL: YOUR_PRODUCTION_URL/api/auth
+      NEXT_PUBLIC_LAB_NAME: Seed ALS Portal
+      # TODO: set to the team contact email
+      NEXT_PUBLIC_ADMIN_EMAIL: YOUR_ADMIN_EMAIL
+      NEXT_PUBLIC_DEBUG: false
+      NEXT_PUBLIC_SHOW_MOBILE_WARNING: false
+      NEXT_PUBLIC_ENABLE_DOWNLOADS: true
+      NEXT_PUBLIC_DISABLE_WELCOME_BANNER: true
+      # TODO: replace with a strong random secret (e.g. openssl rand -base64 32)
+      NEXTAUTH_SECRET: YOUR_NEXTAUTH_SECRET
+      SECRET: YOUR_SECRET
+    volumes:
+      - stage-data:/usr/src/public/static/dms_user_assets
+    networks:
+      - platform-network
+
+volumes:
+  stage-data:
+
+networks:
+  platform-network:
+    driver: bridge


### PR DESCRIPTION
## Summary
Add production Docker Compose configuration for stage-only deployment

## Changes

**New files:**
- `docker-compose.prod.yml` — production Docker Compose with only the `stage` service, no `depends_on`, and placeholder environment variables for production configuration

**Modified files:**
- `Makefile` — add `make prod` and `make prod-down` commands for starting and stopping the production deployment

## Issues
Closes #68