### PR TITLE
Implement API tests

### DIFF
--- a/apps/stage/jest.config.js
+++ b/apps/stage/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('jest').Config} */
+module.exports = {
+	testEnvironment: 'node',
+	testMatch: ['**/tests/**/*.test.ts', '**/tests/**/*.test.js'],
+	moduleNameMapper: {
+		'^@/(.*)$': '<rootDir>/$1',
+	},
+	transformIgnorePatterns: ['/node_modules/(?!(url-join)/)'],
+};

--- a/apps/stage/tests/egaApi.test.ts
+++ b/apps/stage/tests/egaApi.test.ts
@@ -1,0 +1,91 @@
+import { fetchAlsStudies, fetchStudyDatasets } from '@/global/services/egaApi';
+
+const mockStudies = [
+	{
+		accession_id: 'EGAS00001000001',
+		title: 'ALS Study 1',
+		abstract: 'An ALS study abstract.',
+		description: null,
+		study_type: 'Case-Control',
+		pubmed_ids: null,
+		external_links: null,
+		is_released: true,
+		released_date: '2020-01-01',
+		is_deprecated: false,
+	},
+];
+
+const mockDatasets = [
+	{
+		accession_id: 'EGAD00001000001',
+		title: 'ALS Dataset 1',
+		description: null,
+		dataset_types: ['Genomic'],
+		technologies: ['Whole Genome Sequencing'],
+		num_samples: 100,
+		access_type: 'controlled',
+		is_in_beacon: false,
+		is_released: true,
+		released_date: '2020-01-01',
+		is_deprecated: false,
+		policy_accession_id: 'EGAP00001000001',
+	},
+];
+
+beforeEach(() => {
+	global.fetch = jest.fn();
+});
+
+afterEach(() => {
+	jest.resetAllMocks();
+});
+
+describe('fetchAlsStudies', () => {
+	it('returns studies array on success', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockStudies,
+		});
+
+		const result = await fetchAlsStudies();
+
+		expect(global.fetch).toHaveBeenCalledWith('/api/ega/studies');
+		expect(result).toEqual(mockStudies);
+	});
+
+	it('throws on non-ok response', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: false,
+			status: 500,
+			statusText: 'Internal Server Error',
+		});
+
+		await expect(fetchAlsStudies()).rejects.toThrow('EGA API error: 500 Internal Server Error');
+	});
+});
+
+describe('fetchStudyDatasets', () => {
+	it('returns datasets array on success', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockDatasets,
+		});
+
+		const result = await fetchStudyDatasets('EGAS00001000001');
+
+		expect(global.fetch).toHaveBeenCalledWith('/api/ega/study-datasets/EGAS00001000001');
+		expect(result).toEqual(mockDatasets);
+	});
+
+	it('throws on non-ok response', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: false,
+			status: 404,
+			statusText: 'Not Found',
+		});
+
+		await expect(fetchStudyDatasets('EGAS00001000001')).rejects.toThrow(
+			'EGA API error: 404 Not Found for /studies/EGAS00001000001/datasets',
+		);
+	});
+});

--- a/apps/stage/tests/monarchApi.test.ts
+++ b/apps/stage/tests/monarchApi.test.ts
@@ -1,0 +1,195 @@
+import { fetchDiseaseEntity, fetchDiseaseAssociations } from '@/global/services/monarchApi';
+import { ALS_ASSOCIATION_CATEGORIES, MONARCH_API_BASE_URL } from '@/global/utils/constants';
+
+const mockEntity = {
+	id: 'MONDO:0004976',
+	name: 'amyotrophic lateral sclerosis',
+	category: 'biolink:Disease',
+	description: 'A motor neuron disease.',
+	synonym: [],
+	exact_synonym: [],
+	namespace: 'MONDO',
+	has_phenotype: [],
+	has_phenotype_label: [],
+	has_phenotype_count: 0,
+	has_descendant: [],
+	has_descendant_label: [],
+	has_descendant_count: 0,
+	causal_gene: [],
+	inheritance: null,
+	mappings: [],
+	association_counts: [],
+	node_hierarchy: { super_classes: [], sub_classes: [] },
+};
+
+const mockAssociationResponse = {
+	limit: 20,
+	offset: 0,
+	total: 1,
+	items: [
+		{
+			id: 'uuid-1',
+			category: ALS_ASSOCIATION_CATEGORIES.DISEASE_TO_PHENOTYPE,
+			subject: 'MONDO:0004976',
+			subject_label: 'amyotrophic lateral sclerosis',
+			subject_namespace: 'MONDO',
+			subject_category: 'biolink:Disease',
+			subject_taxon: null,
+			subject_taxon_label: null,
+			predicate: 'biolink:has_phenotype',
+			object: 'HP:0002355',
+			object_label: 'Difficulty walking',
+			object_namespace: 'HP',
+			object_category: 'biolink:PhenotypicFeature',
+			object_closure_label: [],
+			provided_by: 'monarch_kg',
+			frequency_qualifier: null,
+			frequency_qualifier_label: null,
+			onset_qualifier: null,
+			onset_qualifier_label: null,
+		},
+	],
+};
+
+beforeEach(() => {
+	global.fetch = jest.fn();
+});
+
+afterEach(() => {
+	jest.resetAllMocks();
+});
+
+describe('fetchDiseaseEntity', () => {
+	it('returns disease entity on success', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockEntity,
+		});
+
+		const result = await fetchDiseaseEntity('MONDO:0004976');
+
+		expect(global.fetch).toHaveBeenCalledWith(`${MONARCH_API_BASE_URL}/entity/MONDO:0004976`);
+		expect(result).toEqual(mockEntity);
+	});
+
+	it('throws on non-ok response', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: false,
+			status: 404,
+			statusText: 'Not Found',
+		});
+
+		await expect(fetchDiseaseEntity('MONDO:0004976')).rejects.toThrow(
+			'Monarch API error: 404 Not Found for entity MONDO:0004976',
+		);
+	});
+});
+
+describe('fetchDiseaseAssociations', () => {
+	it('uses subject param for DISEASE_TO_PHENOTYPE category', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockAssociationResponse,
+		});
+
+		await fetchDiseaseAssociations('MONDO:0004976', ALS_ASSOCIATION_CATEGORIES.DISEASE_TO_PHENOTYPE);
+
+		const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+		expect(calledUrl).toContain('subject=MONDO%3A0004976');
+		expect(calledUrl).not.toContain('entity=');
+		expect(calledUrl).not.toContain('object=');
+	});
+
+	it('uses entity param for GENE_TO_PHENOTYPE category', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockAssociationResponse,
+		});
+
+		await fetchDiseaseAssociations('MONDO:0004976', ALS_ASSOCIATION_CATEGORIES.GENE_TO_PHENOTYPE);
+
+		const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+		expect(calledUrl).toContain('entity=MONDO%3A0004976');
+		expect(calledUrl).not.toContain('subject=');
+		expect(calledUrl).not.toContain('object=');
+	});
+
+	it('uses object param for CAUSAL_GENE_TO_DISEASE category', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockAssociationResponse,
+		});
+
+		await fetchDiseaseAssociations('MONDO:0004976', ALS_ASSOCIATION_CATEGORIES.CAUSAL_GENE_TO_DISEASE);
+
+		const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+		expect(calledUrl).toContain('object=MONDO%3A0004976');
+		expect(calledUrl).not.toContain('subject=');
+		expect(calledUrl).not.toContain('entity=');
+	});
+
+	it('uses object param for CORRELATED_GENE_TO_DISEASE category', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockAssociationResponse,
+		});
+
+		await fetchDiseaseAssociations('MONDO:0004976', ALS_ASSOCIATION_CATEGORIES.CORRELATED_GENE_TO_DISEASE);
+
+		const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+		expect(calledUrl).toContain('object=MONDO%3A0004976');
+	});
+
+	it('uses object param for GENOTYPE_TO_DISEASE category', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockAssociationResponse,
+		});
+
+		await fetchDiseaseAssociations('MONDO:0004976', ALS_ASSOCIATION_CATEGORIES.GENOTYPE_TO_DISEASE);
+
+		const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+		expect(calledUrl).toContain('object=MONDO%3A0004976');
+	});
+
+	it('applies limit and offset to the URL', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockAssociationResponse,
+		});
+
+		await fetchDiseaseAssociations('MONDO:0004976', ALS_ASSOCIATION_CATEGORIES.DISEASE_TO_PHENOTYPE, 50, 100);
+
+		const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+		expect(calledUrl).toContain('limit=50');
+		expect(calledUrl).toContain('offset=100');
+	});
+
+	it('returns association response on success', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockAssociationResponse,
+		});
+
+		const result = await fetchDiseaseAssociations(
+			'MONDO:0004976',
+			ALS_ASSOCIATION_CATEGORIES.DISEASE_TO_PHENOTYPE,
+		);
+
+		expect(result).toEqual(mockAssociationResponse);
+	});
+
+	it('throws on non-ok response', async () => {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: false,
+			status: 503,
+			statusText: 'Service Unavailable',
+		});
+
+		await expect(
+			fetchDiseaseAssociations('MONDO:0004976', ALS_ASSOCIATION_CATEGORIES.DISEASE_TO_PHENOTYPE),
+		).rejects.toThrow(
+			`Monarch API error: 503 Service Unavailable for associations ${ALS_ASSOCIATION_CATEGORIES.DISEASE_TO_PHENOTYPE}`,
+		);
+	});
+});

--- a/apps/stage/tests/tsconfig.json
+++ b/apps/stage/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"types": ["jest", "node"]
+	},
+	"include": ["**/*.ts"]
+}

--- a/apps/stage/tsconfig.json
+++ b/apps/stage/tsconfig.json
@@ -18,6 +18,7 @@
 		"incremental": true,
 		"noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied `any` type.. */,
 		"strictNullChecks": true /* When type checking, take into account `null` and `undefined`. */,
+		"ignoreDeprecations": "6.0",
 		"baseUrl": "./",
 		"paths": {
 			"@/public": ["./public"],


### PR DESCRIPTION
## Summary

Add Jest API tests for EGA and Monarch services

## Changes

### New files

- `apps/stage/jest.config.js` — Jest configuration with node environment, `@/` path alias, and ESM support for `url-join`
- `apps/stage/tests/tsconfig.json` — TypeScript config for tests extending the main one, adds Jest and Node types
- `apps/stage/tests/egaApi.test.ts` — tests for `fetchAlsStudies` and `fetchStudyDatasets` (success + HTTP error)
- `apps/stage/tests/monarchApi.test.ts` — tests for `fetchDiseaseEntity` and `fetchDiseaseAssociations` (all categories, limit/offset, success + HTTP error)

### Modified files

- `apps/stage/tsconfig.json` — add `ignoreDeprecations: "6.0"` to silence TypeScript 6.x baseUrl deprecation warning

## Issues

Closes #45