### PR TITLE
Handle removed ALS study IDs

### DIFF
--- a/.github/scripts/update-ega-als-ids.js
+++ b/.github/scripts/update-ega-als-ids.js
@@ -81,15 +81,18 @@ async function main() {
 	console.log(`Current list has ${currentIds.length} IDs`);
 
 	const currentSet = new Set(currentIds);
+	const foundSet = new Set(foundIds);
 	const newIds = foundIds.filter((id) => !currentSet.has(id));
+	const removedIds = currentIds.filter((id) => !foundSet.has(id));
 
-	if (newIds.length === 0) {
-		console.log('No new ALS studies found. List is up to date.');
+	if (newIds.length === 0 && removedIds.length === 0) {
+		console.log('No changes detected. List is up to date.');
 		process.exit(0);
 	}
 
-	console.log(`Found ${newIds.length} new ID(s): ${newIds.join(', ')}`);
-	fs.writeFileSync(OUTPUT_PATH, JSON.stringify(newIds, null, 2));
+	if (newIds.length > 0) console.log(`Found ${newIds.length} new ID(s): ${newIds.join(', ')}`);
+	if (removedIds.length > 0) console.log(`Found ${removedIds.length} removed ID(s): ${removedIds.join(', ')}`);
+	fs.writeFileSync(OUTPUT_PATH, JSON.stringify({ newIds, removedIds }, null, 2));
 	process.exit(1);
 }
 

--- a/.github/workflows/update-ega-als-ids.yml
+++ b/.github/workflows/update-ega-als-ids.yml
@@ -26,25 +26,27 @@ jobs:
         run: node .github/scripts/update-ega-als-ids.js
         continue-on-error: true
 
-      - name: Update constants.ts with new IDs
+      - name: Update constants.ts with new and removed IDs
         if: steps.detect.outcome == 'failure'
         run: |
-          NEW_IDS=$(node -e "
+          node -e "
             const fs = require('fs');
-            const newIds = JSON.parse(fs.readFileSync('.github/scripts/new-als-ids.json', 'utf8'));
+            const { newIds, removedIds } = JSON.parse(fs.readFileSync('.github/scripts/new-als-ids.json', 'utf8'));
             const src = fs.readFileSync('apps/stage/global/utils/constants.ts', 'utf8');
             const match = src.match(/ALS_EGA_ACCESSION_IDS[^=]*=\s*\[([\s\S]*?)\];/);
             const current = [...match[1].matchAll(/'(EGAS\w+)'/g)].map(m => m[1]);
-            const merged = [...new Set([...current, ...newIds])].sort();
+            const removedSet = new Set(removedIds);
+            const merged = [...new Set([...current.filter(id => !removedSet.has(id)), ...newIds])].sort();
             const entries = merged.map(id => \`\t'\${id}',\`).join('\n');
             const updated = src.replace(
               /ALS_EGA_ACCESSION_IDS[^=]*=\s*\[([\s\S]*?)\];/,
               \`ALS_EGA_ACCESSION_IDS: string[] = [\n\${entries}\n];\`
             );
             fs.writeFileSync('apps/stage/global/utils/constants.ts', updated);
-            console.log(newIds.join(', '));
-          ")
-          echo "NEW_IDS=$NEW_IDS" >> $GITHUB_ENV
+            const envFile = process.env.GITHUB_ENV;
+            if (newIds.length) fs.appendFileSync(envFile, 'NEW_IDS=' + newIds.join(', ') + '\n');
+            if (removedIds.length) fs.appendFileSync(envFile, 'REMOVED_IDS=' + removedIds.join(', ') + '\n');
+          "
 
       - name: Commit and push changes
         if: steps.detect.outcome == 'failure'
@@ -65,18 +67,29 @@ jobs:
           if [ -n "$EXISTING" ]; then
             echo "PR #$EXISTING already exists, skipping creation."
           else
-            gh pr create \
-              --title "[Bot] New ALS studies detected in EGA" \
-              --body "## New ALS studies detected
+            BODY="## EGA ALS accession IDs updated
 
-          The monthly EGA scan found new ALS-related studies not present in the current accession ID list.
+          The monthly EGA scan detected changes in the ALS study list."
+            if [ -n "$NEW_IDS" ]; then
+              BODY="$BODY
 
-          **New IDs added:** \`${{ env.NEW_IDS }}\`
+          **New IDs added:** \`$NEW_IDS\`"
+            fi
+            if [ -n "$REMOVED_IDS" ]; then
+              BODY="$BODY
 
-          Please review and merge if the studies are relevant.
+          **IDs removed** (no longer returned by the EGA API): \`$REMOVED_IDS\`"
+            fi
+            BODY="$BODY
+
+          Please review and merge if the changes are correct.
 
           ---
-          *Opened automatically by the [Update EGA ALS Accession IDs](.github/workflows/update-ega-als-ids.yml) workflow.*" \
+          *Opened automatically by the [Update EGA ALS Accession IDs](.github/workflows/update-ega-als-ids.yml) workflow.*"
+
+            gh pr create \
+              --title "[Bot] EGA ALS accession IDs updated" \
+              --body "$BODY" \
               --base TechBioLab \
               --label "automated" \
               --label "data-update"


### PR DESCRIPTION
## Summary

Add removed ID detection to EGA ALS update workflow

## Changes

### Modified files

- `.github/scripts/update-ega-als-ids.js` — add `removedIds` detection (IDs in `constants.ts` not returned by EGA API); output JSON now contains `{ newIds, removedIds }` instead of a plain array; exits with code 1 if either list is non-empty
- `.github/workflows/update-ega-als-ids.yml` — update `constants.ts` step to apply both additions and removals; set `NEW_IDS` and `REMOVED_IDS` env vars via `GITHUB_ENV`; build PR body dynamically showing only the relevant sections; update PR title to generic `[Bot] EGA ALS accession IDs updated`

## Issues

Closes #70