### PR TITLE
PPI network fit-view button

### DIFF
--- a/apps/stage/components/pages/diseaseModel/PPINetwork.tsx
+++ b/apps/stage/components/pages/diseaseModel/PPINetwork.tsx
@@ -1,9 +1,6 @@
 import { css, useTheme } from '@emotion/react';
-import dynamic from 'next/dynamic';
 import { useEffect, useRef, useState, ReactElement, useCallback } from 'react';
 import defaultTheme from '../../theme';
-
-const ForceGraph2D = dynamic(() => import('react-force-graph-2d') as any, { ssr: false });
 
 interface PPINode {
 	id: string;
@@ -35,12 +32,19 @@ const PPINetwork = (): ReactElement => {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const graphRef = useRef<any>(null);
 
+	const [ForceGraph2D, setForceGraph2D] = useState<any>(null);
 	const [data, setData] = useState<PPINetworkData | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
 	const [hoveredNode, setHoveredNode] = useState<PPINode | null>(null);
 	const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
+
+	useEffect(() => {
+		import('react-force-graph-2d').then((mod) => {
+			setForceGraph2D(() => mod.default ?? mod);
+		});
+	}, []);
 
 	useEffect(() => {
 		fetch('/data/ppi-network.json')
@@ -291,7 +295,7 @@ const PPINetwork = (): ReactElement => {
 					</div>
 				)}
 
-				{!loading && !error && data && (
+				{!loading && !error && data && ForceGraph2D && (
 					<>
 						<ForceGraph2D
 							ref={graphRef}

--- a/apps/stage/tsconfig.json
+++ b/apps/stage/tsconfig.json
@@ -36,5 +36,5 @@
 		]
 	},
 	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "additional.d.ts"],
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules", "tests"]
 }


### PR DESCRIPTION
## Summary
Fix the fit-view button on the Disease Model PPI network, and prevent Jest types from leaking into Next.js compilation

## Changes
> All paths relative to `apps/stage/`

**Modified files:**
- `components/pages/diseaseModel/PPINetwork.tsx` — replace `next/dynamic` with a `useEffect`-based import so the component's `forwardRef` API is preserved and `graphRef.current.zoomToFit` is callable
- `tsconfig.json` — add `"tests"` to `exclude` so Next.js does not compile test files with missing Jest types

## Issues
Closes #79